### PR TITLE
Add reflector (UKW) data model and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+React Native TypeScript app simulating a historical Enigma cipher machine. Users configure rotors and a plugboard, then type on a keyboard to encrypt/decrypt messages.
+
+## Common Commands
+
+- `npm test` — Run all Jest tests
+- `npm test -- --testPathPattern=<pattern>` — Run a single test file (e.g. `Keyboard.test`)
+- `npm run lint` — TypeScript type-check + ESLint
+- `npm run lint:fix` — Auto-fix lint issues
+- `npm run format` — Prettier + lint fix
+- `npm run start` — Start Metro bundler
+- `npm run android` / `npm run ios` — Build and run on device/emulator
+
+## Architecture
+
+**Navigation:** Drawer navigator (App.tsx) with screens: Enigma Machine, Break Cipher, About, Settings. The Machine screen uses a nested Stack navigator (Settings → Keyboard).
+
+**State management:** Redux Toolkit with two slices:
+- `rotors` — 5 pre-configured rotors with step indices, letter mappings, and current position. Actions: `updateRotorAvailability`, `updateRotorCurrentIndex`.
+- `plugboard` — Key-value letter pair mappings (cables). Actions: `addCable`, `removeCable`.
+
+**Store config:** `src/store/store.tsx`
+**Redux slices:** `src/features/rotors/features.tsx`, `src/features/plugboard/index.tsx`
+**Types/interfaces:** `src/types/interfaces.tsx`
+
+## Code Layout
+
+- `src/components/pages/machine/` — Main Enigma interface (keyboard + settings with rotors and plugboard)
+- `src/constants/labels.tsx` — All UI strings (centralized for i18n readiness)
+- `src/constants/selectors.tsx` — testID constants and helper functions (`currentLetter()`, `selectRotorButton()`, `letterButton()`)
+- `src/styles/index.tsx` — Shared StyleSheet definitions
+- `src/utils/test-utils.tsx` — Custom `render()` wrapping components with Redux store + SafeAreaProvider
+
+## Testing Conventions
+
+- Tests are colocated with components (`.test.tsx` suffix)
+- Always use the custom `render` from `src/utils/test-utils.tsx` (provides Redux store + SafeAreaProvider)
+- Use testID constants from `src/constants/selectors.tsx` — never hardcode testID strings
+- Mock `@react-navigation/native` and `react-native-paper` Portal in component tests
+- Framework: Jest + @testing-library/react-native
+
+## Code Style
+
+- Import sorting enforced via `simple-import-sort` ESLint plugin
+- Single quotes, trailing commas everywhere, arrow parens always
+- Keyboard layout follows German Enigma: `QWERTZUIOP / ASDFGHJKL / YXCVBNM`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# Enigma Machine
+
+A React Native TypeScript app simulating a historical Enigma cipher machine. Users configure rotors and a plugboard, then type on a keyboard to encrypt and decrypt messages.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (v16 or later recommended)
+- [React Native CLI environment](https://reactnative.dev/docs/environment-setup) set up for your target platform (Android and/or iOS)
+- For Android: Android Studio with an emulator or a connected device
+- For iOS (macOS only): Xcode with CocoaPods installed
+
+## Setup
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/<your-username>/EnigmaProject.git
+   cd EnigmaProject
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+3. For iOS, install CocoaPods:
+
+   ```bash
+   cd ios && pod install && cd ..
+   ```
+
+## Running the App
+
+Start the Metro bundler:
+
+```bash
+npm run start
+```
+
+Then, in a separate terminal, build and run on your target platform:
+
+```bash
+# Android
+npm run android
+
+# iOS
+npm run ios
+```
+
+## Testing
+
+Run all tests:
+
+```bash
+npm test
+```
+
+Run a specific test file:
+
+```bash
+npm test -- --testPathPattern=<pattern>
+```
+
+## Linting and Formatting
+
+Type-check and lint:
+
+```bash
+npm run lint
+```
+
+Auto-fix lint issues:
+
+```bash
+npm run lint:fix
+```
+
+Format with Prettier and fix lint issues:
+
+```bash
+npm run format
+```
+
+## Project Structure
+
+```
+src/
+├── components/pages/machine/   # Main Enigma interface (keyboard + settings)
+├── constants/                  # UI strings (labels) and testID selectors
+├── features/                   # Redux slices (rotors, plugboard, reflector)
+├── store/                      # Redux store configuration
+├── styles/                     # Shared StyleSheet definitions
+├── types/                      # TypeScript interfaces
+└── utils/                      # Test utilities
+```
+
+## Architecture
+
+- **Navigation:** Drawer navigator with screens for the Enigma Machine, Break Cipher, About, and Settings. The Machine screen uses a nested Stack navigator.
+- **State management:** Redux Toolkit with slices for rotors, plugboard, and reflector.
+- **Keyboard layout:** Follows the historical German Enigma layout — `QWERTZUIOP / ASDFGHJKL / YXCVBNM`.

--- a/src/features/reflector/index.tsx
+++ b/src/features/reflector/index.tsx
@@ -1,0 +1,52 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+import {
+  ReflectorsState,
+  UpdateSelectedReflectorInterface,
+} from '../../types';
+
+const initialState: ReflectorsState = {
+  reflectors: {
+    1: {
+      id: 1,
+      name: 'UKW-A',
+      config: {
+        mapping: 'EJMZALYXVBWFCRQUONTSPIKHGD'.split(''),
+      },
+    },
+    2: {
+      id: 2,
+      name: 'UKW-B',
+      config: {
+        mapping: 'YRUHQSLDPXNGOKMIEBFZCWVJAT'.split(''),
+      },
+    },
+    3: {
+      id: 3,
+      name: 'UKW-C',
+      config: {
+        mapping: 'FVPJIAOYEDRZXWGCTKUQSBNMHL'.split(''),
+      },
+    },
+  },
+  selectedReflectorId: 2,
+};
+
+export const reflectorSlice = createSlice({
+  name: 'reflector',
+  initialState,
+  reducers: {
+    selectReflector: (
+      state,
+      action: PayloadAction<UpdateSelectedReflectorInterface>,
+    ) => {
+      state.selectedReflectorId = action.payload.id;
+    },
+  },
+});
+
+// Action creators are generated for each case reducer function
+export const { selectReflector } = reflectorSlice.actions;
+
+export default reflectorSlice.reducer;

--- a/src/features/reflector/reflector.test.tsx
+++ b/src/features/reflector/reflector.test.tsx
@@ -1,0 +1,49 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import reflectorReducer, { selectReflector } from './index';
+
+const createStore = () =>
+  configureStore({
+    reducer: {
+      reflector: reflectorReducer,
+    },
+  });
+
+describe('Reflector slice', () => {
+  it('should have 3 reflectors in initial state', () => {
+    const store = createStore();
+    const state = store.getState().reflector;
+    expect(Object.keys(state.reflectors)).toHaveLength(3);
+  });
+
+  it('should have UKW-B (id 2) selected by default', () => {
+    const store = createStore();
+    const state = store.getState().reflector;
+    expect(state.selectedReflectorId).toBe(2);
+    expect(state.reflectors[2].name).toBe('UKW-B');
+  });
+
+  it('should change selected reflector with selectReflector action', () => {
+    const store = createStore();
+    store.dispatch(selectReflector({ id: 1 }));
+    expect(store.getState().reflector.selectedReflectorId).toBe(1);
+
+    store.dispatch(selectReflector({ id: 3 }));
+    expect(store.getState().reflector.selectedReflectorId).toBe(3);
+  });
+
+  it('should have valid reflector mappings (26 chars, no letter maps to itself)', () => {
+    const store = createStore();
+    const { reflectors } = store.getState().reflector;
+    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+    Object.values(reflectors).forEach((reflector) => {
+      const { mapping } = reflector.config;
+      expect(mapping).toHaveLength(26);
+
+      mapping.forEach((mappedLetter, index) => {
+        expect(mappedLetter).not.toBe(alphabet[index]);
+      });
+    });
+  });
+});

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -1,12 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
 
 import plugboardReducer from '../features/plugboard';
+import reflectorReducer from '../features/reflector';
 import rotorsReducer from '../features/rotors/features';
 
 export const store = configureStore({
   reducer: {
     rotors: rotorsReducer,
     plugboard: plugboardReducer,
+    reflector: reflectorReducer,
   },
 });
 

--- a/src/types/interfaces.tsx
+++ b/src/types/interfaces.tsx
@@ -75,3 +75,22 @@ export type NextScreenNavigationProp = NavigationProp<
   MachineStackParamList,
   'Keyboard'
 >;
+
+export interface ReflectorConfig {
+  mapping: string[];
+}
+
+export interface ReflectorState {
+  id: number;
+  name: string;
+  config: ReflectorConfig;
+}
+
+export interface ReflectorsState {
+  reflectors: { [id: number]: ReflectorState };
+  selectedReflectorId: number;
+}
+
+export interface UpdateSelectedReflectorInterface {
+  id: number;
+}

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -13,11 +13,12 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { Provider } from 'react-redux';
 
 import plugboardReducer from '../features/plugboard';
+import reflectorReducer from '../features/reflector';
 import rotorsReducer from '../features/rotors/features';
 import type { RootState } from '../store/store';
 import { RotorState } from '../types';
 
-type ReducerTypes = Pick<RootState, 'rotors'>;
+type ReducerTypes = Pick<RootState, 'rotors' | 'reflector'>;
 type TStore = EnhancedStore<ReducerTypes>;
 
 type CustomRenderOptions = {
@@ -63,6 +64,7 @@ function render(ui: ReactElement, options?: CustomRenderOptions) {
       reducer: {
         rotors: rotorsReducer,
         plugboard: plugboardReducer,
+        reflector: reflectorReducer,
       },
       preloadedState,
     });


### PR DESCRIPTION
## Summary
- Add reflector (UKW) Redux slice with three historical reflectors (UKW-A, UKW-B, UKW-C), defaulting to UKW-B
- Add TypeScript interfaces (`ReflectorConfig`, `ReflectorState`, `ReflectorsState`) and register the reducer in the store and test utilities
- Add unit tests validating initial state, reflector selection, and mapping integrity (26 chars, no self-mappings)
- Add project README with setup, testing, linting, and running instructions

## Test plan
- [x] `npm test` — all 18 tests pass (including 4 new reflector tests)
- [x] `npm run lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)