### PR TITLE
Add rotor stepping with double-stepping turnover

### DIFF
--- a/src/features/rotors/features.tsx
+++ b/src/features/rotors/features.tsx
@@ -11,7 +11,7 @@ const initialState: RotorsState = {
   1: {
     isAvailable: true,
     config: {
-      stepIndex: 2,
+      stepIndex: 16,
       displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
       mappedLetters: 'JGDQOXUSCAMIFRVTPNEWKBLZYH'.split(''),
       currentIndex: 0,
@@ -21,7 +21,7 @@ const initialState: RotorsState = {
   2: {
     isAvailable: true,
     config: {
-      stepIndex: 2,
+      stepIndex: 4,
       displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
       mappedLetters: 'NTZPSFBOKMWRCJDIVLAEYUXHGQ'.split(''),
       currentIndex: 0,
@@ -31,7 +31,7 @@ const initialState: RotorsState = {
   3: {
     isAvailable: true,
     config: {
-      stepIndex: 2,
+      stepIndex: 21,
       displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
       mappedLetters: 'JVIUBHTCDYAKEQZPOSGXNRMWFL'.split(''),
       currentIndex: 0,
@@ -41,7 +41,7 @@ const initialState: RotorsState = {
   4: {
     isAvailable: true,
     config: {
-      stepIndex: 2,
+      stepIndex: 9,
       displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
       mappedLetters: 'QYHOGNECVPUZTFDJAXWMKISRBL'.split(''),
       currentIndex: 0,
@@ -51,7 +51,7 @@ const initialState: RotorsState = {
   5: {
     isAvailable: true,
     config: {
-      stepIndex: 2,
+      stepIndex: 25,
       displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
       mappedLetters: 'QWERTZUIOASDFGHJKPYXCVBNML'.split(''),
       currentIndex: 0,

--- a/src/utils/enigma.test.tsx
+++ b/src/utils/enigma.test.tsx
@@ -8,13 +8,14 @@ import {
   passThroughPlugboard,
   passThroughReflector,
   passThroughRotor,
+  stepRotors,
 } from './enigma';
 
 // Rotor I from the app's initial state
 const rotorI: RotorState = {
   isAvailable: true,
   config: {
-    stepIndex: 2,
+    stepIndex: 16,
     displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
     mappedLetters: 'JGDQOXUSCAMIFRVTPNEWKBLZYH'.split(''),
     currentIndex: 0,
@@ -26,7 +27,7 @@ const rotorI: RotorState = {
 const rotorII: RotorState = {
   isAvailable: true,
   config: {
-    stepIndex: 2,
+    stepIndex: 4,
     displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
     mappedLetters: 'NTZPSFBOKMWRCJDIVLAEYUXHGQ'.split(''),
     currentIndex: 0,
@@ -38,7 +39,7 @@ const rotorII: RotorState = {
 const rotorIII: RotorState = {
   isAvailable: true,
   config: {
-    stepIndex: 2,
+    stepIndex: 21,
     displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
     mappedLetters: 'JVIUBHTCDYAKEQZPOSGXNRMWFL'.split(''),
     currentIndex: 0,
@@ -182,5 +183,74 @@ describe('encryptLetter', () => {
       reflectorB,
     );
     expect(decrypted).toBe('H');
+  });
+});
+
+describe('stepRotors', () => {
+  const makeRotor = (
+    id: number,
+    stepIndex: number,
+    currentIndex: number,
+  ): RotorState => ({
+    isAvailable: true,
+    config: {
+      stepIndex,
+      displayedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
+      mappedLetters: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''),
+      currentIndex,
+    },
+    id,
+  });
+
+  it('right rotor always steps', () => {
+    const rotors = [makeRotor(1, 16, 0), makeRotor(2, 4, 0), makeRotor(3, 21, 0)];
+    const result = stepRotors(rotors);
+    expect(result[0].config.currentIndex).toBe(1);
+    expect(result[1].config.currentIndex).toBe(0);
+    expect(result[2].config.currentIndex).toBe(0);
+  });
+
+  it('middle rotor steps when right rotor is at its notch', () => {
+    const rotors = [makeRotor(1, 16, 16), makeRotor(2, 4, 0), makeRotor(3, 21, 0)];
+    const result = stepRotors(rotors);
+    expect(result[0].config.currentIndex).toBe(17);
+    expect(result[1].config.currentIndex).toBe(1);
+    expect(result[2].config.currentIndex).toBe(0);
+  });
+
+  it('left rotor steps when middle rotor is at its notch', () => {
+    const rotors = [makeRotor(1, 16, 0), makeRotor(2, 4, 4), makeRotor(3, 21, 0)];
+    const result = stepRotors(rotors);
+    expect(result[0].config.currentIndex).toBe(1);
+    expect(result[1].config.currentIndex).toBe(5);
+    expect(result[2].config.currentIndex).toBe(1);
+  });
+
+  it('double-stepping: middle rotor steps on two consecutive keypresses', () => {
+    // First keypress: right rotor reaches its notch, middle rotor steps to its own notch
+    const rotors = [makeRotor(1, 16, 16), makeRotor(2, 4, 3), makeRotor(3, 21, 0)];
+    const afterFirst = stepRotors(rotors);
+    expect(afterFirst[0].config.currentIndex).toBe(17);
+    expect(afterFirst[1].config.currentIndex).toBe(4);
+    expect(afterFirst[2].config.currentIndex).toBe(0);
+
+    // Second keypress: middle rotor is at its notch, so it steps again (double-step) along with left
+    const afterSecond = stepRotors(afterFirst);
+    expect(afterSecond[0].config.currentIndex).toBe(18);
+    expect(afterSecond[1].config.currentIndex).toBe(5);
+    expect(afterSecond[2].config.currentIndex).toBe(1);
+  });
+
+  it('wraps around from 25 to 0', () => {
+    const rotors = [makeRotor(1, 16, 25), makeRotor(2, 4, 0), makeRotor(3, 21, 0)];
+    const result = stepRotors(rotors);
+    expect(result[0].config.currentIndex).toBe(0);
+  });
+
+  it('does not mutate the original array', () => {
+    const rotors = [makeRotor(1, 16, 0), makeRotor(2, 4, 0), makeRotor(3, 21, 0)];
+    const originalRight = rotors[0].config.currentIndex;
+    stepRotors(rotors);
+    expect(rotors[0].config.currentIndex).toBe(originalRight);
   });
 });

--- a/src/utils/enigma.tsx
+++ b/src/utils/enigma.tsx
@@ -6,52 +6,72 @@ import {
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-export const passThroughPlugboard = (
+const findDirectCableMapping = (
   letter: string,
   cables: PlugboardCable,
-): string => {
-  // Check if letter is a key in the cables
-  if (cables[letter]) {
-    return cables[letter];
-  }
-  // Check if letter is a value in the cables (bidirectional)
+): string | undefined => (cables[letter] ? cables[letter] : undefined);
+
+const findReverseCableMapping = (
+  letter: string,
+  cables: PlugboardCable,
+): string | undefined => {
   for (const key in cables) {
     if (cables[key] === letter) {
       return key;
     }
   }
-  return letter;
+  return undefined;
+};
+
+export const passThroughPlugboard = (
+  letter: string,
+  cables: PlugboardCable,
+): string =>
+  findDirectCableMapping(letter, cables) ??
+  findReverseCableMapping(letter, cables) ??
+  letter;
+
+const applyOffset = (index: number, offset: number, size: number): number =>
+  (index + offset) % size;
+
+const removeOffset = (index: number, offset: number, size: number): number =>
+  (index - offset + size) % size;
+
+const forwardPassThroughRotor = (
+  letter: string,
+  rotor: RotorState,
+): string => {
+  const { mappedLetters, currentIndex } = rotor.config;
+  const size = mappedLetters.length;
+
+  const shiftedIndex = applyOffset(ALPHABET.indexOf(letter), currentIndex, size);
+  const outputLetter = mappedLetters[shiftedIndex];
+  const adjustedIndex = removeOffset(ALPHABET.indexOf(outputLetter), currentIndex, size);
+  return ALPHABET[adjustedIndex];
+};
+
+const reversePassThroughRotor = (
+  letter: string,
+  rotor: RotorState,
+): string => {
+  const { mappedLetters, currentIndex } = rotor.config;
+  const size = mappedLetters.length;
+
+  const shiftedIndex = applyOffset(ALPHABET.indexOf(letter), currentIndex, size);
+  const letterAtShifted = ALPHABET[shiftedIndex];
+  const mappedIndex = mappedLetters.indexOf(letterAtShifted);
+  const adjustedIndex = removeOffset(mappedIndex, currentIndex, size);
+  return ALPHABET[adjustedIndex];
 };
 
 export const passThroughRotor = (
   letter: string,
   rotor: RotorState,
   reverse: boolean,
-): string => {
-  const { displayedLetters, mappedLetters, currentIndex } = rotor.config;
-  const size = displayedLetters.length;
-
-  // Get the index of the input letter in the alphabet
-  const inputIndex = ALPHABET.indexOf(letter);
-
-  // Apply the rotor's current position offset
-  const shiftedIndex = (inputIndex + currentIndex) % size;
-
-  if (!reverse) {
-    // Forward: displayedLetters → mappedLetters
-    const outputLetter = mappedLetters[shiftedIndex];
-    // Remove the offset from the output
-    const outputIndex = ALPHABET.indexOf(outputLetter);
-    const adjustedIndex = (outputIndex - currentIndex + size) % size;
-    return ALPHABET[adjustedIndex];
-  } else {
-    // Reverse: mappedLetters → displayedLetters
-    const letterAtShifted = ALPHABET[shiftedIndex];
-    const mappedIndex = mappedLetters.indexOf(letterAtShifted);
-    const adjustedIndex = (mappedIndex - currentIndex + size) % size;
-    return ALPHABET[adjustedIndex];
-  }
-};
+): string =>
+  reverse
+    ? reversePassThroughRotor(letter, rotor)
+    : forwardPassThroughRotor(letter, rotor);
 
 export const passThroughReflector = (
   letter: string,
@@ -61,30 +81,47 @@ export const passThroughReflector = (
   return reflector.config.mapping[index];
 };
 
+const advanceRotor = (rotor: RotorState): RotorState => ({
+  ...rotor,
+  config: {
+    ...rotor.config,
+    currentIndex: (rotor.config.currentIndex + 1) % 26,
+  },
+});
+
+const isAtNotch = (rotor: RotorState): boolean =>
+  rotor.config.currentIndex === rotor.config.stepIndex;
+
+export const stepRotors = (rotors: RotorState[]): RotorState[] => {
+  const [right, middle, left] = rotors;
+
+  if (isAtNotch(middle)) {
+    return [advanceRotor(right), advanceRotor(middle), advanceRotor(left)];
+  }
+
+  if (isAtNotch(right)) {
+    return [advanceRotor(right), advanceRotor(middle), left];
+  }
+
+  return [advanceRotor(right), middle, left];
+};
+
+const passForwardThroughRotors = (signal: string, rotors: RotorState[]): string =>
+  rotors.reduce((s, rotor) => passThroughRotor(s, rotor, false), signal);
+
+const passReverseThroughRotors = (signal: string, rotors: RotorState[]): string =>
+  [...rotors].reverse().reduce((s, rotor) => passThroughRotor(s, rotor, true), signal);
+
 export const encryptLetter = (
   letter: string,
   rotors: RotorState[],
   plugboard: PlugboardCable,
   reflector: ReflectorState,
 ): string => {
-  // Signal path: plugboard → rotors forward (right to left) → reflector → rotors reverse (left to right) → plugboard
   let signal = passThroughPlugboard(letter, plugboard);
-
-  // Forward pass through rotors (right to left: index 0 is rightmost)
-  for (let i = 0; i < rotors.length; i++) {
-    signal = passThroughRotor(signal, rotors[i], false);
-  }
-
-  // Through reflector
+  signal = passForwardThroughRotors(signal, rotors);
   signal = passThroughReflector(signal, reflector);
-
-  // Reverse pass through rotors (left to right: last rotor first)
-  for (let i = rotors.length - 1; i >= 0; i--) {
-    signal = passThroughRotor(signal, rotors[i], true);
-  }
-
-  // Back through plugboard
+  signal = passReverseThroughRotors(signal, rotors);
   signal = passThroughPlugboard(signal, plugboard);
-
   return signal;
 };


### PR DESCRIPTION
## Summary
- Set historical Enigma turnover notch positions (Q, E, V, J, Z) for rotors I–V
- Add `stepRotors` pure utility function implementing right-rotor-always-steps, middle/left turnover, and the double-stepping anomaly
- Refactor `enigma.tsx` to replace explanatory comments with self-documenting extracted functions

## Test plan
- [x] 6 new `stepRotors` unit tests covering normal stepping, turnover, double-stepping, wrap-around, and immutability
- [x] All 41 existing + new tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)