### PR TITLE
Add app-wide dark theme

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,55 +5,43 @@ import { name as appName } from './app.json';
 import App from './src/App';
 import { Provider } from 'react-redux';
 import { store } from './src/store/store';
+import { colors } from './src/theme/colors';
 
 const theme = {
   ...DefaultTheme,
-  
-  
-    "colors": {
-      "primary": "rgb(52, 92, 168)",
-      "onPrimary": "rgb(255, 255, 255)",
-      "primaryContainer": "rgb(217, 226, 255)",
-      "onPrimaryContainer": "rgb(0, 26, 67)",
-      "secondary": "rgb(174, 44, 70)",
-      "onSecondary": "rgb(255, 255, 255)",
-      "secondaryContainer": "rgb(255, 218, 219)",
-      "onSecondaryContainer": "rgb(64, 0, 15)",
-      "tertiary": "rgb(0, 104, 116)",
-      "onTertiary": "rgb(255, 255, 255)",
-      "tertiaryContainer": "rgb(151, 240, 255)",
-      "onTertiaryContainer": "rgb(0, 31, 36)",
-      "error": "rgb(186, 26, 26)",
-      "onError": "rgb(255, 255, 255)",
-      "errorContainer": "rgb(255, 218, 214)",
-      "onErrorContainer": "rgb(65, 0, 2)",
-      "background": "rgb(254, 251, 255)",
-      "onBackground": "rgb(27, 27, 31)",
-      "surface": "rgb(254, 251, 255)",
-      "onSurface": "rgb(27, 27, 31)",
-      "surfaceVariant": "rgb(225, 226, 236)",
-      "onSurfaceVariant": "rgb(68, 71, 79)",
-      "outline": "rgb(117, 119, 128)",
-      "outlineVariant": "rgb(197, 198, 208)",
-      "shadow": "rgb(0, 0, 0)",
-      "scrim": "rgb(0, 0, 0)",
-      "inverseSurface": "rgb(48, 48, 52)",
-      "inverseOnSurface": "rgb(242, 240, 244)",
-      "inversePrimary": "rgb(175, 198, 255)",
-      "elevation": {
-        "level0": "transparent",
-        "level1": "rgb(244, 243, 251)",
-        "level2": "rgb(238, 238, 248)",
-        "level3": "rgb(232, 234, 245)",
-        "level4": "rgb(230, 232, 245)",
-        "level5": "rgb(226, 229, 243)"
-      },
-      "surfaceDisabled": "rgba(27, 27, 31, 0.12)",
-      "onSurfaceDisabled": "rgba(27, 27, 31, 0.38)",
-      "backdrop": "rgba(46, 48, 56, 0.4)"
-    }
-  
-  
+  colors: {
+    ...DefaultTheme.colors,
+    primary: colors.accent,
+    onPrimary: colors.background,
+    primaryContainer: colors.surfaceAlt,
+    onPrimaryContainer: colors.textPrimary,
+    secondary: colors.accent,
+    onSecondary: colors.background,
+    secondaryContainer: colors.surfaceAlt,
+    onSecondaryContainer: colors.textPrimary,
+    background: colors.background,
+    onBackground: colors.textPrimary,
+    surface: colors.surface,
+    onSurface: colors.textPrimary,
+    surfaceVariant: colors.surfaceAlt,
+    onSurfaceVariant: colors.textSecondary,
+    outline: colors.border,
+    outlineVariant: colors.border,
+    inverseSurface: colors.textPrimary,
+    inverseOnSurface: colors.background,
+    inversePrimary: colors.accent,
+    elevation: {
+      level0: 'transparent',
+      level1: colors.surface,
+      level2: colors.surface,
+      level3: colors.surfaceAlt,
+      level4: colors.surfaceAlt,
+      level5: colors.surfaceAlt,
+    },
+    surfaceDisabled: 'rgba(245, 240, 232, 0.12)',
+    onSurfaceDisabled: 'rgba(245, 240, 232, 0.38)',
+    backdrop: 'rgba(0, 0, 0, 0.6)',
+  },
 };
 
 export default function Main() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,22 @@ import { NavigationContainer } from '@react-navigation/native';
 import React, { FunctionComponent } from 'react';
 
 import { About, BreakCipher, Machine, Settings } from './components';
+import { colors } from './theme/colors';
 
 const App: FunctionComponent = () => {
   const Drawer = createDrawerNavigator();
   return (
     <NavigationContainer>
-      <Drawer.Navigator initialRouteName='Enigma'>
+      <Drawer.Navigator
+        initialRouteName='Enigma'
+        screenOptions={{
+          drawerStyle: { backgroundColor: colors.background },
+          drawerActiveTintColor: colors.accent,
+          drawerInactiveTintColor: colors.textPrimary,
+          headerStyle: { backgroundColor: colors.surface },
+          headerTintColor: colors.textPrimary,
+        }}
+      >
         <Drawer.Screen
           name='Enigma'
           component={Machine}

--- a/src/components/pages/about/About.tsx
+++ b/src/components/pages/about/About.tsx
@@ -1,10 +1,23 @@
 import { FunctionComponent } from 'react';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '../../../theme/colors';
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: 16,
+  },
+  text: {
+    color: colors.textPrimary,
+  },
+});
 
 export const About: FunctionComponent = () => {
   return (
-    <View>
-      <Text>About enigma</Text>
+    <View style={styles.screen}>
+      <Text style={styles.text}>About enigma</Text>
     </View>
   );
 };

--- a/src/components/pages/breakCipher/BreakCipher.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.tsx
@@ -1,10 +1,23 @@
 import { FunctionComponent } from 'react';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '../../../theme/colors';
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: 16,
+  },
+  text: {
+    color: colors.textPrimary,
+  },
+});
 
 export const BreakCipher: FunctionComponent = () => {
   return (
-    <View>
-      <Text>Break a cipher</Text>
+    <View style={styles.screen}>
+      <Text style={styles.text}>Break a cipher</Text>
     </View>
   );
 };

--- a/src/components/pages/machine/keyboard/BackButton.tsx
+++ b/src/components/pages/machine/keyboard/BackButton.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from 'react';
 import { IconButton } from 'react-native-paper';
 
 import { KEYBOARD_GO_BACK_BUTTON } from '../../../../constants';
+import { colors } from '../../../../theme/colors';
 import { NextScreenNavigationProp } from '../../../../types';
 
 export const BackButton: FunctionComponent = () => {
@@ -14,7 +15,7 @@ export const BackButton: FunctionComponent = () => {
   return (
     <IconButton
       icon='arrow-left'
-      iconColor='#F5F0E8'
+      iconColor={colors.textPrimary}
       size={24}
       onPress={navigateToPreviousScreen}
       testID={KEYBOARD_GO_BACK_BUTTON}

--- a/src/components/pages/machine/keyboard/Keyboard.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.tsx
@@ -7,6 +7,7 @@ import { MESSAGE_DISPLAY, OUTPUT_LETTER_DISPLAY } from '../../../../constants';
 import { updateRotorCurrentIndex } from '../../../../features/rotors/features';
 import { RootState } from '../../../../store/store';
 import { keyboardStyles } from '../../../../styles';
+import { colors } from '../../../../theme/colors';
 import {
   encryptLetter,
   keyboardLetterButton,
@@ -99,9 +100,9 @@ export const Keyboard: FunctionComponent = () => {
             <Chip
               key={cable}
               mode='flat'
-              textStyle={{ color: '#F5F0E8' }}
+              textStyle={{ color: colors.textPrimary }}
               style={keyboardStyles.plugboardChip}
-              theme={{ colors: { secondaryContainer: '#3a3530' } }}
+              theme={{ colors: { secondaryContainer: colors.surfaceAlt } }}
             >
               {plugboardChipText(cable, plugboard[cable])}
             </Chip>
@@ -120,8 +121,8 @@ export const Keyboard: FunctionComponent = () => {
                 compact={true}
                 style={keyboardStyles.key}
                 theme={{ roundness: 10 }}
-                textColor='#F5F0E8'
-                buttonColor='#3a3530'
+                textColor={colors.textPrimary}
+                buttonColor={colors.surfaceAlt}
                 onPress={() => handleKeyPress(key)}
               >
                 {key}

--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -1,12 +1,20 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { FunctionComponent } from 'react';
-import { View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Button } from 'react-native-paper';
 
 import { ENCRYPT_MESSAGE, ENCRYPT_MESSAGE_BUTTON } from '../../../../constants';
+import { colors } from '../../../../theme/colors';
 import { NextScreenNavigationProp } from '../../../../types';
 import { Plugboard } from './plugboard';
 import { Rotors } from './rotors';
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});
 
 export const Settings: FunctionComponent = () => {
   const navigation = useNavigation<NextScreenNavigationProp>();
@@ -14,10 +22,14 @@ export const Settings: FunctionComponent = () => {
     navigation.navigate('Keyboard');
   };
   return (
-    <View>
+    <View style={styles.screen}>
       <Rotors />
       <Plugboard />
-      <Button onPress={navigateToNextItem} testID={ENCRYPT_MESSAGE_BUTTON}>
+      <Button
+        onPress={navigateToNextItem}
+        testID={ENCRYPT_MESSAGE_BUTTON}
+        textColor={colors.accent}
+      >
         {ENCRYPT_MESSAGE}
       </Button>
     </View>

--- a/src/components/pages/machine/settings/plugboard/Plugboard.tsx
+++ b/src/components/pages/machine/settings/plugboard/Plugboard.tsx
@@ -7,6 +7,7 @@ import { ADD_CABLE, ADD_CABLE_MODAL_BUTTON } from '../../../../../constants';
 import { removeCable } from '../../../../../features/plugboard';
 import { RootState } from '../../../../../store/store';
 import { rotorStyles } from '../../../../../styles';
+import { colors } from '../../../../../theme/colors';
 import { plugboardChipText } from '../../../../../utils';
 import { AddCableModal } from './addCableModal';
 
@@ -43,7 +44,8 @@ export const Plugboard: FunctionComponent = () => {
               )
             }
             closeIcon={'close-circle'}
-            style={{ margin: 4 }}
+            style={{ margin: 4, borderColor: colors.border }}
+            textStyle={{ color: colors.textPrimary }}
           >
             {plugboardChipText(cable, plugboard[cable])}
           </Chip>

--- a/src/components/pages/machine/settings/rotors/Rotor.tsx
+++ b/src/components/pages/machine/settings/rotors/Rotor.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../../../features/rotors/features';
 import { RootState } from '../../../../../store/store';
 import { rotorStyles } from '../../../../../styles';
+import { colors } from '../../../../../theme/colors';
 import { RotorState } from '../../../../../types';
 import { currentLetter, currentRotor } from '../../../../../utils';
 import { ChangeIndexModal } from './ChangeIndexModal';
@@ -92,7 +93,7 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
                   testID={REMOVE_ROTOR_BUTTON}
                   icon='close-circle'
                   mode='contained-tonal'
-                  iconColor='#9c2a2a'
+                  iconColor={colors.destructive}
                   onPress={removeRotor}
                 />
               )}

--- a/src/components/pages/settings/Settings.tsx
+++ b/src/components/pages/settings/Settings.tsx
@@ -1,10 +1,23 @@
 import { FunctionComponent } from 'react';
-import { Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { colors } from '../../../theme/colors';
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: 16,
+  },
+  text: {
+    color: colors.textPrimary,
+  },
+});
 
 export const Settings: FunctionComponent = () => {
   return (
-    <View>
-      <Text>App settings</Text>
+    <View style={styles.screen}>
+      <Text style={styles.text}>App settings</Text>
     </View>
   );
 };

--- a/src/styles/index.tsx
+++ b/src/styles/index.tsx
@@ -1,5 +1,7 @@
 import { Dimensions, StyleSheet } from 'react-native';
 
+import { colors } from '../theme/colors';
+
 const KEYS_IN_TOP_ROW = 10;
 const KEY_MARGIN = 2;
 const ROW_PADDING = 4;
@@ -31,7 +33,7 @@ export const rotorStyles = StyleSheet.create({
     paddingHorizontal: 0,
   },
   selectRotor: {
-    backgroundColor: 'white',
+    backgroundColor: colors.surface,
     padding: 20,
     marginHorizontal: 50,
     marginVertical: 30,
@@ -48,7 +50,7 @@ export const rotorStyles = StyleSheet.create({
 export const keyboardStyles = StyleSheet.create({
   screen: {
     flex: 1,
-    backgroundColor: '#1a1a1a',
+    backgroundColor: colors.background,
   },
   container: {
     flexDirection: 'column',
@@ -70,7 +72,7 @@ export const keyboardStyles = StyleSheet.create({
     marginVertical: 3,
     justifyContent: 'center',
     paddingHorizontal: 0,
-    borderColor: '#5a534d',
+    borderColor: colors.border,
     borderWidth: 1.5,
   },
   outputContainer: {
@@ -82,11 +84,11 @@ export const keyboardStyles = StyleSheet.create({
   outputLetter: {
     fontSize: 48,
     fontWeight: 'bold',
-    color: '#FFD700',
+    color: colors.accent,
   },
   messageText: {
     fontSize: 16,
-    color: '#E0E0E0',
+    color: colors.textSecondary,
     letterSpacing: 2,
     paddingHorizontal: 10,
     marginTop: 12,
@@ -101,14 +103,14 @@ export const keyboardStyles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 6,
-    backgroundColor: '#2a2a2a',
-    borderColor: '#5a534d',
+    backgroundColor: colors.surface,
+    borderColor: colors.border,
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
   },
   rotorWindowText: {
-    color: '#F5F0E8',
+    color: colors.textPrimary,
     fontWeight: 'bold',
     fontSize: 18,
   },
@@ -121,7 +123,7 @@ export const keyboardStyles = StyleSheet.create({
   },
   plugboardChip: {
     margin: 3,
-    borderColor: '#5a534d',
+    borderColor: colors.border,
     borderWidth: 1,
   },
 });

--- a/src/theme/colors.tsx
+++ b/src/theme/colors.tsx
@@ -1,0 +1,10 @@
+export const colors = {
+  background: '#1a1a1a',
+  surface: '#2a2a2a',
+  surfaceAlt: '#3a3530',
+  border: '#5a534d',
+  textPrimary: '#F5F0E8',
+  textSecondary: '#E0E0E0',
+  accent: '#FFD700',
+  destructive: '#9c2a2a',
+};


### PR DESCRIPTION
## Summary
- Create centralized color palette (`src/theme/colors.tsx`) as single source of truth for all colors
- Apply dark vintage theme from the Keyboard screen across the entire app: drawer navigator, PaperProvider theme, Settings, Rotors, Plugboard, About, Break Cipher, and app Settings pages
- Replace all hardcoded hex color values with palette references for easy future light mode support

## Test plan
- [x] All 52 existing tests pass
- [x] TypeScript type-check clean
- [x] Pre-commit hooks (ESLint + Prettier) pass
- [ ] Visual check: all screens have dark background, cream/gold text, no white flashes when navigating
- [ ] Verify drawer sidebar has dark background with gold active tint
- [ ] Verify modals inherit dark styling from PaperProvider theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)