### PR TITLE
feat: add content to About page

### DIFF
--- a/src/components/pages/about/About.tsx
+++ b/src/components/pages/about/About.tsx
@@ -1,23 +1,84 @@
 import React, { FunctionComponent } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
+import {
+  ABOUT_CODEBREAKERS_BODY,
+  ABOUT_CODEBREAKERS_HEADING,
+  ABOUT_HISTORY_BODY,
+  ABOUT_HISTORY_HEADING,
+  ABOUT_HOW_IT_WORKS_BODY,
+  ABOUT_HOW_IT_WORKS_HEADING,
+  ABOUT_TITLE,
+} from '../../../constants/labels';
 import { colors } from '../../../theme/colors';
 
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
     backgroundColor: colors.background,
-    padding: 16,
   },
-  text: {
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  title: {
+    color: colors.accent,
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 24,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionHeading: {
+    color: colors.accent,
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  sectionDivider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginBottom: 12,
+  },
+  sectionBody: {
     color: colors.textPrimary,
+    fontSize: 15,
+    lineHeight: 22,
   },
 });
+
+const AboutSection: FunctionComponent<{ heading: string; body: string }> = ({
+  heading,
+  body,
+}) => (
+  <View style={styles.section}>
+    <Text style={styles.sectionHeading}>{heading}</Text>
+    <View style={styles.sectionDivider} />
+    <Text style={styles.sectionBody}>{body}</Text>
+  </View>
+);
 
 export const About: FunctionComponent = () => {
   return (
     <View style={styles.screen}>
-      <Text style={styles.text}>About enigma</Text>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.title}>{ABOUT_TITLE}</Text>
+        <AboutSection
+          heading={ABOUT_HISTORY_HEADING}
+          body={ABOUT_HISTORY_BODY}
+        />
+        <AboutSection
+          heading={ABOUT_HOW_IT_WORKS_HEADING}
+          body={ABOUT_HOW_IT_WORKS_BODY}
+        />
+        <AboutSection
+          heading={ABOUT_CODEBREAKERS_HEADING}
+          body={ABOUT_CODEBREAKERS_BODY}
+        />
+      </ScrollView>
     </View>
   );
 };

--- a/src/constants/labels.tsx
+++ b/src/constants/labels.tsx
@@ -30,3 +30,17 @@ export const KNOWN_PLAINTEXT_HINT =
   'Both methods require some known or suspected plaintext';
 export const COMMON_CRIBS_HINT = 'Common cribs: WETTER, KEINE, OBERKOMMANDO';
 export const TAP_TO_EXPAND = 'Tap a position to see alignment';
+
+export const ABOUT_TITLE = 'The Enigma Machine';
+
+export const ABOUT_HISTORY_HEADING = 'History';
+export const ABOUT_HISTORY_BODY =
+  'The Enigma machine was a cipher device used by Nazi Germany during World War II to protect military communications. Invented by Arthur Scherbius in the early 1920s and adopted by the German military in the late 1920s, it was considered unbreakable by its operators. Millions of messages were encrypted using Enigma throughout the war.';
+
+export const ABOUT_HOW_IT_WORKS_HEADING = 'How It Works';
+export const ABOUT_HOW_IT_WORKS_BODY =
+  'Enigma uses a combination of rotors, a plugboard, and a reflector to scramble letters. When a key is pressed, an electrical signal passes through the plugboard (which swaps pairs of letters), then through a series of rotating cipher wheels (rotors), through a reflector that sends the signal back through the rotors in reverse, and finally through the plugboard again before lighting up the encrypted letter.\n\nThe rotors step forward with each keypress — much like an odometer — ensuring that the same letter typed twice in a row produces two different ciphertext letters. This polyalphabetic substitution made Enigma far more secure than simpler ciphers.';
+
+export const ABOUT_CODEBREAKERS_HEADING = 'The Codebreakers';
+export const ABOUT_CODEBREAKERS_BODY =
+  'Breaking Enigma was a collaborative effort spanning decades. Polish mathematician Marian Rejewski first cracked early Enigma variants in the 1930s using mathematical analysis, sharing his work with British and French intelligence shortly before the war.\n\nAt Bletchley Park, Alan Turing and Gordon Welchman improved on the Polish "Bomba" to create the electromechanical Bombe, a machine that could systematically eliminate incorrect Enigma settings. By exploiting predictable message structures — known as "cribs" — codebreakers could narrow down millions of possible configurations in hours.\n\nThe intelligence produced, codenamed ULTRA, is widely credited with shortening the war by two to four years.';


### PR DESCRIPTION
## Summary
- Replaces the placeholder About page with informative historical content
- Adds three sections: History, How It Works, and The Codebreakers
- Content covers the Enigma machine's WWII role, the rotor/plugboard/reflector mechanics, and key codebreakers (Rejewski, Turing, Welchman)

## Changes
- `src/constants/labels.tsx` — Added 7 new string constants for all About page copy (i18n-ready)
- `src/components/pages/about/About.tsx` — Rebuilt with `ScrollView`, a reusable `AboutSection` component, and styling consistent with the rest of the app

## Test plan
- [ ] Open the About page from the drawer navigator
- [ ] Verify all three sections (History, How It Works, The Codebreakers) display correctly
- [ ] Verify the page is scrollable on smaller screens
- [ ] Verify styling (gold headings, dividers, dark background) matches the rest of the app

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)