### PR TITLE
chore: add .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+node_modules/
+android/
+ios/
+coverage/
+babel.config.js
+metro.config.js
+jest.config.js


### PR DESCRIPTION
## Summary
- Adds `.eslintignore` to prevent ESLint from scanning `node_modules/`, `android/`, `ios/`, `coverage/`, and config files (`babel.config.js`, `metro.config.js`, `jest.config.js`)

## Why
Reduces lint time and prevents false positives from generated/vendored code.

Closes #17

## Test plan
- [ ] Run `npm run lint` and verify it completes without scanning excluded directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)