### PR TITLE
chore: configure lint-staged to auto-fix on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "eslint",
-      "prettier --check"
+      "eslint --fix",
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Updates `lint-staged` config in `package.json` to run `eslint --fix` and `prettier --write` instead of check-only commands

## Why
Auto-fixing on commit is a better developer experience — minor formatting issues get corrected automatically rather than blocking the commit.

Closes #18

## Test plan
- [ ] Make a small formatting change to a `.ts`/`.tsx` file and commit — verify lint-staged auto-fixes and re-stages it

🤖 Generated with [Claude Code](https://claude.com/claude-code)