### PR TITLE
fix: resolve ESLint no-await-sync-events conflict with RNTL v14

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,7 @@ export default tseslint.config(
       ...testingLibrary.configs['flat/react'].rules,
       'testing-library/await-async-queries': 'error',
       'testing-library/no-await-sync-queries': 'error',
+      'testing-library/no-await-sync-events': 'off',
       'testing-library/no-debugging-utils': 'warn',
       'testing-library/no-dom-import': 'off',
     },

--- a/src/components/pages/breakCipher/BreakCipher.test.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/no-await-sync-events */
 import React from 'react';
 
 import {

--- a/src/components/pages/machine/keyboard/BackButton.test.tsx
+++ b/src/components/pages/machine/keyboard/BackButton.test.tsx
@@ -22,7 +22,6 @@ describe(`BackButton`, () => {
   };
   it(`goes back to previous stack item`, async () => {
     await renderComponent();
-    // eslint-disable-next-line testing-library/no-await-sync-events
     await fireEvent.press(screen.getByTestId(KEYBOARD_GO_BACK_BUTTON));
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });

--- a/src/components/pages/machine/keyboard/Keyboard.test.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/no-await-sync-events */
 import React from 'react';
 
 import {

--- a/src/components/pages/machine/settings/Settings.test.tsx
+++ b/src/components/pages/machine/settings/Settings.test.tsx
@@ -22,7 +22,6 @@ describe(`Settings`, () => {
   };
   it(`navigates to keyboard`, async () => {
     await renderComponent();
-    // eslint-disable-next-line testing-library/no-await-sync-events
     await fireEvent.press(screen.getByTestId(ENCRYPT_MESSAGE_BUTTON));
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith('Keyboard');

--- a/src/components/pages/machine/settings/plugboard/Plugboard.test.tsx
+++ b/src/components/pages/machine/settings/plugboard/Plugboard.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/no-await-sync-events */
 import React from 'react';
 
 import {

--- a/src/components/pages/machine/settings/plugboard/SelectLetterButton.test.tsx
+++ b/src/components/pages/machine/settings/plugboard/SelectLetterButton.test.tsx
@@ -23,7 +23,6 @@ describe(`SelectLetterButton`, () => {
   };
   it(`calls updateLetter function`, async () => {
     await renderComponent();
-    // eslint-disable-next-line testing-library/no-await-sync-events
     await fireEvent.press(screen.getByTestId(`${SELECT_INPUT_LETTER}1`));
     expect(mockSetLetter).toHaveBeenCalledWith('B');
     expect(mockSetAvailableLetteres).toHaveBeenCalledWith([

--- a/src/components/pages/machine/settings/plugboard/addCableModa.test.tsx
+++ b/src/components/pages/machine/settings/plugboard/addCableModa.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/no-await-sync-events */
 import React from 'react';
 
 import {

--- a/src/components/pages/machine/settings/plugboard/addCableModal.tsx
+++ b/src/components/pages/machine/settings/plugboard/addCableModal.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { Modal } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -20,34 +20,27 @@ export const AddCableModal: FunctionComponent<AddCableModalProps> = ({
   setModalVisible,
 }) => {
   const plugboard = useSelector((state: RootState) => state.plugboard);
-  const [availableLetters, setAvailableLetters] = useState<string[]>(
-    [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'].filter(
-      (letter) => !JSON.stringify(plugboard).includes(letter),
-    ),
-  );
-  const [inputLetter, setInputLetter] = useState<null | string>(null);
-  const [outputLetter, setOutputLetter] = useState<null | string>(null);
+  const [inputLetter, setInputLetter] = useState<string | null>(null);
   const dispatch = useDispatch();
-  useEffect(() => {
-    if (inputLetter !== null && outputLetter !== null) {
-      dispatch(
-        addCable({
-          inputLetter,
-          outputLetter,
-        }),
-      );
-      setModalVisible(false);
-      setInputLetter(null);
-      setOutputLetter(null);
-    }
-  }, [inputLetter, outputLetter]);
-  useEffect(() => {
-    setAvailableLetters(
+
+  const availableLetters = useMemo(
+    () =>
       [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'].filter(
         (letter) => !JSON.stringify(plugboard).includes(letter),
       ),
-    );
-  }, [plugboard]);
+    [plugboard],
+  );
+
+  const availableOutputLetters = useMemo(
+    () => availableLetters.filter((letter) => letter !== inputLetter),
+    [availableLetters, inputLetter],
+  );
+
+  const handleOutputLetterSelect = (letter: string) => {
+    dispatch(addCable({ inputLetter: inputLetter!, outputLetter: letter }));
+    setModalVisible(false);
+    setInputLetter(null);
+  };
   return (
     <Modal
       visible={modalVisible}
@@ -60,16 +53,16 @@ export const AddCableModal: FunctionComponent<AddCableModalProps> = ({
             setLetter={setInputLetter}
             displayText={SELECT_INPUT_LETTER_DISPLAY}
             availableLetters={availableLetters}
-            setAvailableLetters={setAvailableLetters}
+            setAvailableLetters={() => {}}
             testID={SELECT_INPUT_LETTER}
           />
         )}
         {inputLetter !== null && (
           <SelectLetterButton
-            setLetter={setOutputLetter}
+            setLetter={handleOutputLetterSelect}
             displayText={SELECT_OUTPUT_LETTER_DISPLAY}
-            availableLetters={availableLetters}
-            setAvailableLetters={setAvailableLetters}
+            availableLetters={availableOutputLetters}
+            setAvailableLetters={() => {}}
             testID={SELECT_OUTPUT_LETTER}
           />
         )}

--- a/src/components/pages/machine/settings/rotors/ChangeIndexModal.test.tsx
+++ b/src/components/pages/machine/settings/rotors/ChangeIndexModal.test.tsx
@@ -30,8 +30,6 @@ describe(`ChangeIndexModal`, () => {
     const setModalMock = jest.fn();
     const setRotorMock = jest.fn();
     await renderComponent(true, setModalMock, ROTOR_1, setRotorMock);
-    // ESLint keeps saying fireEvent needs an await and is sync
-    // eslint-disable-next-line testing-library/no-await-sync-events
     await fireEvent.press(screen.getByTestId(letterButton('B', 1)));
     expect(setRotorMock).toHaveBeenCalledWith(ROTOR_1);
     expect(setModalMock).toHaveBeenCalledWith(false);

--- a/src/components/pages/machine/settings/rotors/Rotor.test.tsx
+++ b/src/components/pages/machine/settings/rotors/Rotor.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable testing-library/no-await-sync-events */
-// THis is due to ESLint both demanding an await and no await for the fireEvents
 import React from 'react';
 
 import {

--- a/src/components/pages/machine/settings/rotors/Rotor.tsx
+++ b/src/components/pages/machine/settings/rotors/Rotor.tsx
@@ -32,7 +32,9 @@ interface RotorProps {
 
 export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
   const rotors = useSelector((state: RootState) => state.rotors.available);
-  const [selectedRotor, setSelectedRotor] = useState<RotorState | null>(null);
+  const [selectedRotorId, setSelectedRotorId] = useState<number | null>(null);
+  const selectedRotor =
+    selectedRotorId !== null ? (rotors[selectedRotorId] ?? null) : null;
   const [isSelectModalOpen, setIsSelectModalOpen] = useState(false);
   const [isChangeIndexModalOpen, setIsChangeIndexModalOpen] = useState(false);
   const dispatch = useDispatch();
@@ -44,35 +46,31 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
       dispatch(
         updateRotorAvailability({ id: selectedRotor.id, isAvailable: true }),
       );
-    setSelectedRotor(null);
+    setSelectedRotorId(null);
     dispatch(clearSelectedRotor({ slotIndex }));
   };
+  const handleSetRotor = (rotor: RotorState | null) => {
+    setSelectedRotorId(rotor?.id ?? null);
+  };
   useEffect(() => {
-    if (selectedRotor) {
-      dispatch(
-        setSelectedRotorAction({ slotIndex, rotorId: selectedRotor.id }),
-      );
+    if (selectedRotorId !== null) {
+      dispatch(setSelectedRotorAction({ slotIndex, rotorId: selectedRotorId }));
     }
-  }, [dispatch, selectedRotor, selectedRotor?.id, slotIndex]);
-  useEffect(() => {
-    if (selectedRotor) {
-      setSelectedRotor(rotors[selectedRotor.id]);
-    }
-  }, [rotors]);
+  }, [dispatch, selectedRotorId, slotIndex]);
   return (
     <View>
       <Portal>
         <RotorSelectModal
           modalVisible={isSelectModalOpen}
           setModalVisible={setIsSelectModalOpen}
-          setRotor={setSelectedRotor}
+          setRotor={handleSetRotor}
           currentRotor={selectedRotor}
         />
         {selectedRotor && (
           <ChangeIndexModal
             modalVisible={isChangeIndexModalOpen}
             setModalVisible={setIsChangeIndexModalOpen}
-            setRotor={setSelectedRotor}
+            setRotor={handleSetRotor}
             currentRotor={selectedRotor}
           />
         )}

--- a/src/components/pages/machine/settings/rotors/RotorSelectModal.test.tsx
+++ b/src/components/pages/machine/settings/rotors/RotorSelectModal.test.tsx
@@ -31,8 +31,6 @@ describe(`RotorSelectModal`, () => {
     const setRotorMock = jest.fn();
     await renderComponent(true, setModalMock, ROTOR_1, setRotorMock);
 
-    // For some reason ESLint claims this line both needs an await and does not
-    // eslint-disable-next-line testing-library/no-await-sync-events
     await fireEvent.press(screen.getByTestId(selectRotorButton(1)));
     expect(setRotorMock).toHaveBeenCalledWith(ROTOR_1);
     expect(setModalMock).toHaveBeenCalledWith(false);

--- a/src/types/interfaces.tsx
+++ b/src/types/interfaces.tsx
@@ -4,7 +4,7 @@ export interface RotorSelectModalProps {
   modalVisible: boolean;
   setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
   currentRotor: RotorState | null;
-  setRotor: React.Dispatch<React.SetStateAction<RotorState | null>>;
+  setRotor: (rotor: RotorState | null) => void;
 }
 
 export interface ChangeIndexModalProps {
@@ -61,9 +61,9 @@ export interface AddCableModalProps {
 }
 
 export interface SelectLetterProps {
-  setLetter: React.Dispatch<React.SetStateAction<string | null>>;
+  setLetter: (letter: string) => void;
   availableLetters: string[];
-  setAvailableLetters: React.Dispatch<React.SetStateAction<string[]>>;
+  setAvailableLetters: (letters: string[]) => void;
   displayText: string;
   testID?: string;
 }


### PR DESCRIPTION
## Summary

- Disables `testing-library/no-await-sync-events` in `eslint.config.mjs` — this rule is a false positive for `@testing-library/react-native` v14, which made `fireEvent` return a `Promise`. The rule still classifies it as sync, causing a direct conflict with `@typescript-eslint/no-floating-promises`. Tracked for re-enablement in #39.
- Removes all `eslint-disable` override comments from test files that were working around this conflict
- Fixes 5 `react-hooks/set-state-in-effect` warnings:
  - `addCableModal.tsx`: replaces two `useEffect`s with `useMemo` + a direct event handler — available letters are now derived values rather than synced state, and the cable dispatch is handled inline rather than as a side effect
  - `Rotor.tsx`: stores only `selectedRotorId` in local state and derives the full `RotorState` from Redux directly, eliminating the effect that was syncing local state with the store

## Test plan

- [ ] `npm run lint` — 0 errors, 0 warnings
- [ ] `npm test` — 73/73 passing