### PR TITLE
chore: add explicit semi rule to Prettier config

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,6 +4,7 @@ module.exports = {
   bracketSpacing: true,
   singleQuote: true,
   jsxSingleQuote: true,
+  semi: true,
   trailingComma: 'all',
   parser: 'typescript',
 };


### PR DESCRIPTION
## Summary
- Adds `semi: true` to `.prettierrc.js` to explicitly document the project's semicolon convention

Closes #19

## Test plan
- [ ] Verify `.prettierrc.js` contains `semi: true`
- [ ] Run `npm run format` to confirm no formatting changes are introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)