### PR TITLE
fix: use ChangeIndexModalProps in ChangeIndexModal

### DIFF
--- a/src/components/pages/machine/settings/rotors/ChangeIndexModal.tsx
+++ b/src/components/pages/machine/settings/rotors/ChangeIndexModal.tsx
@@ -7,10 +7,10 @@ import { SELECT_NEW_LETTER } from '../../../../../constants';
 import { updateRotorCurrentIndex } from '../../../../../features/rotors/features';
 import { RootState } from '../../../../../store/store';
 import { rotorStyles } from '../../../../../styles';
-import { RotorSelectModalProps } from '../../../../../types';
+import { ChangeIndexModalProps } from '../../../../../types';
 import { letterButton } from '../../../../../utils';
 
-export const ChangeIndexModal: FunctionComponent<RotorSelectModalProps> = ({
+export const ChangeIndexModal: FunctionComponent<ChangeIndexModalProps> = ({
   modalVisible,
   setModalVisible,
   currentRotor,

--- a/src/types/interfaces.tsx
+++ b/src/types/interfaces.tsx
@@ -8,9 +8,10 @@ export interface RotorSelectModalProps {
 }
 
 export interface ChangeIndexModalProps {
-  rotor: RotorState;
   modalVisible: boolean;
   setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  currentRotor: RotorState | null;
+  setRotor: (rotor: RotorState | null) => void;
 }
 
 export interface RotorConfig {


### PR DESCRIPTION
## Summary
- Defines a proper `ChangeIndexModalProps` interface with `currentRotor` and `setRotor` props
- Updates `ChangeIndexModal` to use `ChangeIndexModalProps` instead of the incorrectly borrowed `RotorSelectModalProps`

## Test plan
- [ ] `ChangeIndexModal` tests pass (`npm test -- --testPathPattern=ChangeIndexModal`)
- [ ] Lint passes (`npm run lint`)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)