### PR TITLE
feat: improve test coverage to 90% with enforced threshold

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,4 +26,12 @@ module.exports = {
   collectCoverage: false,
   collectCoverageFrom: ['src/**/*.tsx'],
   coverageReporters: ['text'],
+  coverageThreshold: {
+    global: {
+      statements: 90,
+      branches: 90,
+      functions: 90,
+      lines: 90,
+    },
+  },
 };

--- a/src/components/pages/machine/settings/plugboard/Plugboard.test.tsx
+++ b/src/components/pages/machine/settings/plugboard/Plugboard.test.tsx
@@ -34,5 +34,5 @@ describe(`Plugboard`, () => {
     expect(
       within(screen.getByTestId(`${SELECT_INPUT_LETTER}1`)).queryAllByText('B'),
     ).toHaveLength(1);
-  });
+  }, 15000);
 });

--- a/src/features/plugboard/plugboard.test.tsx
+++ b/src/features/plugboard/plugboard.test.tsx
@@ -1,0 +1,38 @@
+import reducer, { addCable, clearPlugboard, removeCable } from './index';
+
+describe('plugboard reducer', () => {
+  it('returns the initial state', () => {
+    const state = reducer(undefined, { type: 'unknown' });
+    expect(state).toEqual({});
+  });
+
+  it('addCable adds a cable mapping', () => {
+    const state = reducer(
+      undefined,
+      addCable({ inputLetter: 'A', outputLetter: 'B' }),
+    );
+    expect(state).toEqual({ A: 'B' });
+  });
+
+  it('removeCable removes a cable mapping', () => {
+    let state = reducer(
+      undefined,
+      addCable({ inputLetter: 'A', outputLetter: 'B' }),
+    );
+    state = reducer(
+      state,
+      removeCable({ inputLetter: 'A', outputLetter: 'B' }),
+    );
+    expect(state).toEqual({});
+  });
+
+  it('clearPlugboard removes all cables', () => {
+    let state = reducer(
+      undefined,
+      addCable({ inputLetter: 'A', outputLetter: 'B' }),
+    );
+    state = reducer(state, addCable({ inputLetter: 'C', outputLetter: 'D' }));
+    state = reducer(state, clearPlugboard());
+    expect(state).toEqual({});
+  });
+});

--- a/src/features/rotors/rotors.test.tsx
+++ b/src/features/rotors/rotors.test.tsx
@@ -1,5 +1,6 @@
 import reducer, {
   clearSelectedRotor,
+  resetRotors,
   setSelectedRotor,
   updateRotorAvailability,
   updateRotorCurrentIndex,
@@ -70,6 +71,19 @@ describe('rotors reducer', () => {
       );
       state = reducer(state, setSelectedRotor({ slotIndex: 0, rotorId: 5 }));
       expect(state.selectedSlots[0]).toBe(5);
+    });
+  });
+
+  describe('resetRotors', () => {
+    it('resets rotors to initial state', () => {
+      let state = reducer(
+        undefined,
+        updateRotorAvailability({ id: 1, isAvailable: false }),
+      );
+      expect(state.available[1].isAvailable).toBe(false);
+      state = reducer(state, resetRotors());
+      expect(state.available[1].isAvailable).toBe(true);
+      expect(state.selectedSlots).toEqual([null, null, null]);
     });
   });
 });

--- a/src/features/settings/settings.test.tsx
+++ b/src/features/settings/settings.test.tsx
@@ -1,0 +1,54 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { configureStore } from '@reduxjs/toolkit';
+
+import reducer, { loadSettings, persistSettings, setTheme } from './index';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+describe('settings reducer', () => {
+  it('returns the initial state', () => {
+    const state = reducer(undefined, { type: 'unknown' });
+    expect(state.theme).toBe('dark');
+  });
+
+  it('setTheme updates the theme', () => {
+    const state = reducer(undefined, setTheme('light'));
+    expect(state.theme).toBe('light');
+  });
+
+  describe('loadSettings', () => {
+    it('loads stored settings from AsyncStorage', async () => {
+      jest
+        .spyOn(AsyncStorage, 'getItem')
+        .mockResolvedValueOnce(JSON.stringify({ theme: 'light' }));
+      const store = configureStore({ reducer: { settings: reducer } });
+      await store.dispatch(loadSettings());
+      expect(store.getState().settings.theme).toBe('light');
+    });
+
+    it('uses initial state when no stored settings', async () => {
+      jest.spyOn(AsyncStorage, 'getItem').mockResolvedValueOnce(null);
+      const store = configureStore({ reducer: { settings: reducer } });
+      await store.dispatch(loadSettings());
+      expect(store.getState().settings.theme).toBe('dark');
+    });
+  });
+
+  describe('persistSettings', () => {
+    it('saves current settings to AsyncStorage', async () => {
+      const setItemSpy = jest
+        .spyOn(AsyncStorage, 'setItem')
+        .mockResolvedValueOnce(undefined);
+      const store = configureStore({ reducer: { settings: reducer } });
+      store.dispatch(setTheme('light'));
+      await store.dispatch(persistSettings() as never);
+      expect(setItemSpy).toHaveBeenCalledWith(
+        '@enigma_settings',
+        JSON.stringify({ theme: 'light' }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added reducer tests for `removeCable`, `clearPlugboard` (plugboard slice), `resetRotors` (rotors slice), and `setTheme`/`loadSettings`/`persistSettings` (settings slice)
- Fixed `Plugboard.test.tsx` test timeout (increased to 15s to accommodate multiple sequential interactions)
- Added `coverageThreshold` to `jest.config.js` enforcing 90% minimum for statements, branches, functions, and lines

## Coverage results
| Metric | Before | After |
|---|---|---|
| Statements | 90.96% | 93.46% |
| Branches | 92% | 93.6% |
| **Functions** | **82.73%** | **90.64%** |
| Lines | 91.39% | 93.64% |

## Test plan
- [ ] `npm test -- --coverage` passes all 83 tests and meets the 90% threshold
- [ ] `npm run lint` passes clean

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)