### PR TITLE
fix: sanitize Break Cipher inputs in real time

### DIFF
--- a/src/components/pages/breakCipher/BreakCipher.test.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.test.tsx
@@ -299,4 +299,29 @@ describe('BreakCipher', () => {
     await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
     expect(mockBruteForceSearchAsync).not.toHaveBeenCalled();
   });
+
+  it('sanitizes ciphertext input to uppercase alpha only', async () => {
+    await render(<BreakCipher />);
+    await fireEvent.changeText(
+      screen.getByTestId(CIPHERTEXT_INPUT),
+      'abc 123!',
+    );
+    expect(screen.getByTestId(CIPHERTEXT_INPUT).props.value).toBe('ABC');
+  });
+
+  it('sanitizes plaintext input to uppercase alpha only', async () => {
+    await render(<BreakCipher />);
+    await fireEvent.changeText(
+      screen.getByTestId(PLAINTEXT_INPUT),
+      'hello world',
+    );
+    expect(screen.getByTestId(PLAINTEXT_INPUT).props.value).toBe('HELLOWORLD');
+  });
+
+  it('sanitizes crib input to uppercase alpha only', async () => {
+    await render(<BreakCipher />);
+    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
+    await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'cr1b!');
+    expect(screen.getByTestId(CRIB_INPUT).props.value).toBe('CRB');
+  });
 });

--- a/src/components/pages/breakCipher/BreakCipher.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.tsx
@@ -557,7 +557,7 @@ export const BreakCipher: FunctionComponent = () => {
         testID={CIPHERTEXT_INPUT}
         label={CIPHERTEXT_LABEL}
         value={ciphertext}
-        onChangeText={setCiphertext}
+        onChangeText={(text) => setCiphertext(sanitizeInput(text))}
         mode='outlined'
         autoCapitalize='characters'
         style={styles.input}
@@ -572,7 +572,7 @@ export const BreakCipher: FunctionComponent = () => {
           testID={PLAINTEXT_INPUT}
           label={KNOWN_PLAINTEXT_LABEL}
           value={plaintext}
-          onChangeText={setPlaintext}
+          onChangeText={(text) => setPlaintext(sanitizeInput(text))}
           mode='outlined'
           autoCapitalize='characters'
           style={styles.input}
@@ -586,7 +586,7 @@ export const BreakCipher: FunctionComponent = () => {
           testID={CRIB_INPUT}
           label={CRIB_LABEL}
           value={crib}
-          onChangeText={setCrib}
+          onChangeText={(text) => setCrib(sanitizeInput(text))}
           mode='outlined'
           autoCapitalize='characters'
           style={styles.input}


### PR DESCRIPTION
## Summary
- Pipe each `TextInput`'s `onChangeText` through `sanitizeInput` before calling the state setter for `ciphertext`, `plaintext`, and `crib`
- Adds 3 tests verifying that lowercase letters, digits, and punctuation are stripped immediately as the user types

## Test plan
- [ ] `npm test -- --testPathPattern=BreakCipher` — all 11 tests pass
- [ ] `npm run lint` — clean

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)