### PR TITLE
feat: add copy button for encrypted message output

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -12,6 +12,11 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
 
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  __esModule: true,
+  default: { setString: jest.fn() },
+}));
+
 jest.mock('react-native-paper', () => {
   const RealModule = jest.requireActual('react-native-paper');
   const React = require('react');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-native/gradle-plugin": "^0.84.1",
         "@react-native/new-app-screen": "^0.84.1",
         "@react-navigation/drawer": "7.9.4",
@@ -2809,6 +2810,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-clipboard/clipboard": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.16.3.tgz",
+      "integrity": "sha512-cMIcvoZKIrShzJHEaHbTAp458R9WOv0fB6UyC7Ek4Qk561Ow/DrzmmJmH/rAZg21Z6ixJ4YSdFDC14crqIBmCQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": ">= 16.9.0",
+        "react-native": ">= 0.61.5",
+        "react-native-macos": ">= 0.61.0",
+        "react-native-windows": ">= 0.61.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-macos": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-community/cli": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native/gradle-plugin": "^0.84.1",
     "@react-native/new-app-screen": "^0.84.1",
     "@react-navigation/drawer": "7.9.4",

--- a/src/components/common/CopyButton.test.tsx
+++ b/src/components/common/CopyButton.test.tsx
@@ -1,0 +1,52 @@
+import { act } from '@testing-library/react-native';
+import React from 'react';
+
+import { COPY_MESSAGE_BUTTON } from '../../constants';
+import { fireEvent, render, screen } from '../../utils/test-utils';
+import { CopyButton } from './CopyButton';
+
+jest.mock('@react-native-clipboard/clipboard', () => ({
+  __esModule: true,
+  default: { setString: jest.fn() },
+}));
+
+const mockClipboard = jest.requireMock<{
+  default: { setString: jest.Mock };
+}>('@react-native-clipboard/clipboard');
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    mockClipboard.default.setString.mockClear();
+  });
+
+  it('renders with copy label', async () => {
+    await render(<CopyButton text='HELLO' />);
+    expect(screen.getByText('Copy')).toBeTruthy();
+  });
+
+  it('copies text to clipboard when pressed', async () => {
+    await render(<CopyButton text='HELLO' />);
+    await fireEvent.press(screen.getByTestId(COPY_MESSAGE_BUTTON));
+    expect(mockClipboard.default.setString).toHaveBeenCalledWith('HELLO');
+  });
+
+  it('shows "Copied!" after being pressed', async () => {
+    jest.useFakeTimers();
+    await render(<CopyButton text='HELLO' />);
+    await fireEvent.press(screen.getByTestId(COPY_MESSAGE_BUTTON));
+    expect(screen.getByText('Copied!')).toBeTruthy();
+    jest.useRealTimers();
+  });
+
+  it('reverts to "Copy" label after 2 seconds', async () => {
+    jest.useFakeTimers();
+    await render(<CopyButton text='HELLO' />);
+    await fireEvent.press(screen.getByTestId(COPY_MESSAGE_BUTTON));
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+    });
+    expect(screen.getByText('Copy')).toBeTruthy();
+    jest.useRealTimers();
+  });
+});

--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -1,0 +1,38 @@
+import Clipboard from '@react-native-clipboard/clipboard';
+import type { FunctionComponent } from 'react';
+import React, { useState } from 'react';
+import { Button } from 'react-native-paper';
+
+import {
+  COPIED_MESSAGE,
+  COPY_MESSAGE,
+  COPY_MESSAGE_BUTTON,
+} from '../../constants';
+import { useThemeColors } from '../../theme/useThemeColors';
+
+interface CopyButtonProps {
+  text: string;
+}
+
+export const CopyButton: FunctionComponent<CopyButtonProps> = ({ text }) => {
+  const [copied, setCopied] = useState(false);
+  const colors = useThemeColors();
+
+  const copyToClipboard = () => {
+    Clipboard.setString(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Button
+      testID={COPY_MESSAGE_BUTTON}
+      mode='text'
+      compact={true}
+      textColor={colors.textPrimary}
+      onPress={copyToClipboard}
+    >
+      {copied ? COPIED_MESSAGE : COPY_MESSAGE}
+    </Button>
+  );
+};

--- a/src/components/common/index.tsx
+++ b/src/components/common/index.tsx
@@ -1,0 +1,1 @@
+export * from './CopyButton';

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,1 +1,2 @@
+export * from './common';
 export * from './pages';

--- a/src/components/pages/machine/keyboard/Keyboard.test.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+  COPY_MESSAGE_BUTTON,
   KEYBOARD_GO_BACK_BUTTON,
   MESSAGE_DISPLAY,
   OUTPUT_LETTER_DISPLAY,
@@ -115,5 +116,16 @@ describe('Keyboard', () => {
     await fireEvent.press(screen.getByTestId(keyboardLetterButton('A')));
     const output = screen.getByTestId(OUTPUT_LETTER_DISPLAY);
     expect(output.props.children).not.toBe('A');
+  });
+
+  it('does not show copy button when message is empty', async () => {
+    await renderComponent();
+    expect(screen.queryByTestId(COPY_MESSAGE_BUTTON)).toBeNull();
+  });
+
+  it('shows copy button after a letter is encrypted', async () => {
+    await renderWithRotorsSelected();
+    await fireEvent.press(screen.getByTestId(keyboardLetterButton('A')));
+    expect(screen.getByTestId(COPY_MESSAGE_BUTTON)).toBeTruthy();
   });
 });

--- a/src/components/pages/machine/keyboard/Keyboard.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.tsx
@@ -15,6 +15,7 @@ import {
   plugboardChipText,
   stepRotors,
 } from '../../../../utils';
+import { CopyButton } from '../../../common';
 import { BackButton } from './BackButton';
 
 export const Keyboard: FunctionComponent = () => {
@@ -95,6 +96,7 @@ export const Keyboard: FunctionComponent = () => {
         <Text testID={MESSAGE_DISPLAY} style={keyboardStyles.messageText}>
           {message}
         </Text>
+        {message.length > 0 && <CopyButton text={message} />}
       </View>
 
       {Object.keys(plugboard).length > 0 && (

--- a/src/constants/labels.tsx
+++ b/src/constants/labels.tsx
@@ -9,6 +9,8 @@ export const ADD_CABLE = 'Add cable to plugboard';
 export const ENCRYPT_MESSAGE = 'Encrypt a message';
 export const KEYBOARD = 'Keyboard';
 export const GO_BACK = 'Go back';
+export const COPY_MESSAGE = 'Copy';
+export const COPIED_MESSAGE = 'Copied!';
 
 export const BREAK_CIPHER_TITLE = 'Break Cipher';
 export const BRUTE_FORCE_TAB = 'Brute Force';

--- a/src/constants/selectors.tsx
+++ b/src/constants/selectors.tsx
@@ -27,3 +27,4 @@ export const BRUTE_FORCE_RESULT_CARD = 'bruteForceResultCard';
 export const DECRYPTED_TEXT_DISPLAY = 'decryptedTextDisplay';
 export const NLP_SCORE_DISPLAY = 'nlpScoreDisplay';
 export const CANCEL_SEARCH_BUTTON = 'cancelSearchButton';
+export const COPY_MESSAGE_BUTTON = 'copyMessageButton';


### PR DESCRIPTION
## Summary
- Adds a reusable `CopyButton` component (`src/components/common/`) that copies text to the device clipboard and shows a temporary "Copied!" label for 2 seconds before reverting
- Keyboard screen renders the button below the encrypted message output, visible only when a message exists
- Installs `@react-native-clipboard/clipboard` for clipboard access

## Test plan
- [ ] Encrypt one or more letters on the Keyboard screen — copy button should appear below the output
- [ ] Tap the copy button — label should change to "Copied!" briefly then revert to "Copy"
- [ ] Paste elsewhere to confirm the encrypted message was copied correctly
- [ ] Verify copy button is absent when no message has been typed

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)