### PR TITLE
feat: add copy button to brute force and crib analysis result cards

### DIFF
--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -12,9 +12,13 @@ import { useThemeColors } from '../../theme/useThemeColors';
 
 interface CopyButtonProps {
   text: string;
+  testID?: string;
 }
 
-export const CopyButton: FunctionComponent<CopyButtonProps> = ({ text }) => {
+export const CopyButton: FunctionComponent<CopyButtonProps> = ({
+  text,
+  testID = COPY_MESSAGE_BUTTON,
+}) => {
   const [copied, setCopied] = useState(false);
   const colors = useThemeColors();
 
@@ -26,7 +30,7 @@ export const CopyButton: FunctionComponent<CopyButtonProps> = ({ text }) => {
 
   return (
     <Button
-      testID={COPY_MESSAGE_BUTTON}
+      testID={testID}
       mode='text'
       compact={true}
       textColor={colors.textPrimary}

--- a/src/components/pages/breakCipher/BreakCipher.test.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.test.tsx
@@ -6,6 +6,7 @@ import {
   BRUTE_FORCE_TAB_BUTTON,
   CANCEL_SEARCH_BUTTON,
   CIPHERTEXT_INPUT,
+  COPY_MESSAGE_BUTTON,
   CRIB_ANALYSIS_TAB_BUTTON,
   CRIB_INPUT,
   CRIB_POSITION_CARD,
@@ -208,6 +209,18 @@ describe('BreakCipher', () => {
     });
   });
 
+  it('brute force result card shows copy button for decrypted text', async () => {
+    await render(<BreakCipher />);
+
+    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABC');
+    await fireEvent.changeText(screen.getByTestId(PLAINTEXT_INPUT), 'XYZ');
+    await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`${COPY_MESSAGE_BUTTON}_0`)).toBeTruthy();
+    });
+  });
+
   it('crib analysis shows ranked result cards when cribSearchAsync returns results', async () => {
     const mockResult: CribSearchResult = {
       rotorIds: [3, 2, 1],
@@ -240,6 +253,40 @@ describe('BreakCipher', () => {
     await waitFor(() => {
       expect(screen.getByTestId(`${BRUTE_FORCE_RESULT_CARD}_0`)).toBeTruthy();
       expect(screen.getByTestId(`${DECRYPTED_TEXT_DISPLAY}_0`)).toBeTruthy();
+    });
+  });
+
+  it('crib analysis result card shows copy button for decrypted text', async () => {
+    const mockResult: CribSearchResult = {
+      rotorIds: [3, 2, 1],
+      reflectorName: 'UKW-B',
+      startingPositions: [0, 0, 0],
+      cribPosition: 0,
+      decryptedText: 'HELLO',
+      nlpScore: 80,
+    };
+    mockCribSearchAsync.mockImplementationOnce(
+      (
+        _c: string,
+        _cr: string,
+        _r: object,
+        _ref: object,
+        onProgress: (p: number) => void,
+      ) => {
+        onProgress(1);
+        return Promise.resolve([mockResult]);
+      },
+    );
+
+    await render(<BreakCipher />);
+    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
+
+    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
+    await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
+    await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`${COPY_MESSAGE_BUTTON}_0`)).toBeTruthy();
     });
   });
 

--- a/src/components/pages/breakCipher/BreakCipher.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.tsx
@@ -33,6 +33,7 @@ import {
   BRUTE_FORCE_TAB_BUTTON,
   CANCEL_SEARCH_BUTTON,
   CIPHERTEXT_INPUT,
+  COPY_MESSAGE_BUTTON,
   CRIB_ANALYSIS_TAB_BUTTON,
   CRIB_INPUT,
   CRIB_POSITION_CARD,
@@ -56,6 +57,7 @@ import {
   cribSearchAsync,
   findCribPositions,
 } from '../../../utils/codebreaking';
+import { CopyButton } from '../../common';
 
 type Tab = 'bruteForce' | 'cribAnalysis';
 
@@ -303,6 +305,10 @@ const BruteForceResults: FunctionComponent<{
             {DECRYPTED_TEXT_LABEL}: {result.decryptedText}
           </Text>
           <NlpBadge score={result.nlpScore} testIdSuffix={String(index)} />
+          <CopyButton
+            text={result.decryptedText}
+            testID={`${COPY_MESSAGE_BUTTON}_${index}`}
+          />
         </View>
       ))}
     </View>
@@ -343,6 +349,10 @@ const CribSearchResults: FunctionComponent<{
             {DECRYPTED_TEXT_LABEL}: {result.decryptedText}
           </Text>
           <NlpBadge score={result.nlpScore} testIdSuffix={String(index)} />
+          <CopyButton
+            text={result.decryptedText}
+            testID={`${COPY_MESSAGE_BUTTON}_${index}`}
+          />
         </View>
       ))}
     </View>


### PR DESCRIPTION
## Summary
- Reuses the `CopyButton` component to add a copy button to each result card in `BruteForceResults` and `CribSearchResults`
- Each button copies `result.decryptedText` to the clipboard with a temporary "Copied!" label
- Copy button testIDs are indexed per card (e.g. `copyMessageButton_0`) consistent with existing card element conventions

## Test plan
- [ ] Run a brute force search with results — each result card should have a Copy button
- [ ] Run a crib analysis with results — each result card should have a Copy button
- [ ] Tap a Copy button — label changes to "Copied!" briefly, then reverts
- [ ] Paste elsewhere to confirm the decrypted text was copied correctly

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)