### PR TITLE
feat: UX improvements for machine settings and keyboard (#61)

### DIFF
--- a/src/components/pages/machine/keyboard/Keyboard.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.tsx
@@ -1,15 +1,28 @@
 import type { FunctionComponent } from 'react';
 import React, { useMemo, useState } from 'react';
 import { Text, View } from 'react-native';
-import { Button, Chip, IconButton } from 'react-native-paper';
+import {
+  Button,
+  Chip,
+  IconButton,
+  Modal,
+  Portal,
+  TextInput,
+} from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
+  CANCEL_LABEL,
   INFO_BUTTON,
   INFO_KEYBOARD_CONTENT,
   INFO_KEYBOARD_TITLE,
   MESSAGE_DISPLAY,
   OUTPUT_LETTER_DISPLAY,
+  PASTE_CONFIRM,
+  PASTE_CONFIRM_BUTTON,
+  PASTE_TEXT_BUTTON,
+  PASTE_TEXT_INPUT,
+  PASTE_TEXT_PLACEHOLDER,
 } from '../../../../constants';
 import { updateRotorCurrentIndex } from '../../../../features/rotors/features';
 import type { RootState } from '../../../../store/store';
@@ -47,6 +60,8 @@ export const Keyboard: FunctionComponent = () => {
   const [outputLetter, setOutputLetter] = useState<string | null>(null);
   const [message, setMessage] = useState('');
   const [infoVisible, setInfoVisible] = useState(false);
+  const [pasteVisible, setPasteVisible] = useState(false);
+  const [pasteInput, setPasteInput] = useState('');
 
   const allRotorsSelected = (): boolean =>
     selectedRotorIds.every((id) => id !== null);
@@ -74,6 +89,37 @@ export const Keyboard: FunctionComponent = () => {
     setMessage((prev) => prev + encrypted);
   };
 
+  const processTextInput = (text: string) => {
+    if (!allRotorsSelected()) return;
+
+    const orderedRotors = selectedRotorIds.map((id) => rotors[id as number]);
+    const reflector = reflectors[selectedReflectorId];
+    let currentRotors = orderedRotors;
+    const results: string[] = [];
+
+    for (const key of text.toUpperCase()) {
+      if (!/[A-Z]/.test(key)) continue;
+      currentRotors = stepRotors(currentRotors);
+      results.push(encryptLetter(key, currentRotors, plugboard, reflector));
+    }
+
+    if (results.length === 0) return;
+
+    currentRotors.forEach((rotor, index) => {
+      dispatch(
+        updateRotorCurrentIndex({
+          id: selectedRotorIds[index] as number,
+          currentIndex: rotor.config.currentIndex,
+        }),
+      );
+    });
+
+    setOutputLetter(results[results.length - 1]);
+    setMessage((prev) => prev + results.join(''));
+    setPasteInput('');
+    setPasteVisible(false);
+  };
+
   const currentRotorLetter = (slotId: number | null): string => {
     if (slotId === null) return '-';
     const rotor = rotors[slotId];
@@ -82,15 +128,65 @@ export const Keyboard: FunctionComponent = () => {
 
   return (
     <View style={keyboardStyles.screen}>
+      <Portal>
+        <Modal
+          visible={pasteVisible}
+          onDismiss={() => setPasteVisible(false)}
+          contentContainerStyle={keyboardStyles.pasteModal}
+        >
+          <TextInput
+            testID={PASTE_TEXT_INPUT}
+            label={PASTE_TEXT_PLACEHOLDER}
+            value={pasteInput}
+            onChangeText={setPasteInput}
+            mode='outlined'
+            autoCapitalize='characters'
+            style={keyboardStyles.pasteInput}
+            textColor={colors.textPrimary}
+            outlineColor={colors.border}
+            activeOutlineColor={colors.accent}
+            theme={{ colors: { onSurfaceVariant: colors.textSecondary } }}
+          />
+          <View style={keyboardStyles.pasteButtonRow}>
+            <Button
+              mode='outlined'
+              textColor={colors.textSecondary}
+              style={{ borderColor: colors.border }}
+              onPress={() => setPasteVisible(false)}
+            >
+              {CANCEL_LABEL}
+            </Button>
+            <Button
+              testID={PASTE_CONFIRM_BUTTON}
+              mode='contained'
+              buttonColor={colors.accent}
+              textColor={colors.background}
+              disabled={pasteInput.length === 0}
+              onPress={() => processTextInput(pasteInput)}
+            >
+              {PASTE_CONFIRM}
+            </Button>
+          </View>
+        </Modal>
+      </Portal>
       <View style={keyboardStyles.headerRow}>
         <BackButton />
-        <IconButton
-          testID={INFO_BUTTON}
-          icon='information'
-          iconColor={colors.textSecondary}
-          size={22}
-          onPress={() => setInfoVisible(true)}
-        />
+        <View style={keyboardStyles.headerActions}>
+          <IconButton
+            testID={PASTE_TEXT_BUTTON}
+            icon='clipboard-text-outline'
+            iconColor={colors.textSecondary}
+            size={22}
+            onPress={() => setPasteVisible(true)}
+          />
+          <IconButton
+            testID={INFO_BUTTON}
+            icon='information'
+            iconColor={colors.textSecondary}
+            size={22}
+            onPress={() => setInfoVisible(true)}
+          />
+        </View>
       </View>
 
       <View style={keyboardStyles.rotorDisplayRow}>

--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent } from 'react';
 import React, { useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Button, IconButton } from 'react-native-paper';
+import { useDispatch } from 'react-redux';
 
 import {
   ENCRYPT_MESSAGE,
@@ -10,7 +11,16 @@ import {
   INFO_BUTTON,
   INFO_SETTINGS_CONTENT,
   INFO_SETTINGS_TITLE,
+  RANDOMIZE_BUTTON,
+  RANDOMIZE_SETTINGS,
 } from '../../../../constants';
+import { addCable, clearPlugboard } from '../../../../features/plugboard';
+import {
+  resetRotors,
+  setSelectedRotor,
+  updateRotorAvailability,
+  updateRotorCurrentIndex,
+} from '../../../../features/rotors/features';
 import type { ColorPalette } from '../../../../theme/colors';
 import { useThemeColors } from '../../../../theme/useThemeColors';
 import type { NextScreenNavigationProp } from '../../../../types';
@@ -18,14 +28,35 @@ import { InfoSidebar } from '../../../InfoSidebar';
 import { Plugboard } from './plugboard';
 import { Rotors } from './rotors';
 
+const ROTOR_IDS = [1, 2, 3, 4, 5];
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+const shuffleArray = <T,>(arr: T[]): T[] => {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+};
+
 const makeStyles = (colors: ColorPalette) =>
   StyleSheet.create({
     screen: {
       flex: 1,
       backgroundColor: colors.background,
     },
-    infoRow: {
-      alignItems: 'flex-end',
+    bottomRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingHorizontal: 8,
+    },
+    infoButton: {
+      position: 'absolute',
+      right: 0,
+      top: 0,
+      zIndex: 1,
     },
   });
 
@@ -34,30 +65,69 @@ export const Settings: FunctionComponent = () => {
   const colors = useThemeColors();
   const styles = useMemo(() => makeStyles(colors), [colors]);
   const [infoVisible, setInfoVisible] = useState(false);
+  const dispatch = useDispatch();
 
   const navigateToNextItem = () => {
     navigation.navigate('Keyboard');
   };
+
+  const randomizeSettings = () => {
+    dispatch(resetRotors());
+    dispatch(clearPlugboard());
+
+    const selectedIds = shuffleArray(ROTOR_IDS).slice(0, 3);
+    selectedIds.forEach((rotorId, slotIndex) => {
+      dispatch(updateRotorAvailability({ id: rotorId, isAvailable: false }));
+      dispatch(setSelectedRotor({ slotIndex, rotorId }));
+      dispatch(
+        updateRotorCurrentIndex({
+          id: rotorId,
+          currentIndex: Math.floor(Math.random() * 26),
+        }),
+      );
+    });
+
+    const letters = shuffleArray([...ALPHABET]);
+    const numCables = 3 + Math.floor(Math.random() * 3);
+    for (let i = 0; i < numCables * 2; i += 2) {
+      dispatch(
+        addCable({ inputLetter: letters[i], outputLetter: letters[i + 1] }),
+      );
+    }
+  };
+
   return (
     <View style={styles.screen}>
-      <View style={styles.infoRow}>
-        <IconButton
-          testID={INFO_BUTTON}
-          icon='information'
-          iconColor={colors.textSecondary}
-          size={22}
-          onPress={() => setInfoVisible(true)}
-        />
-      </View>
+      <IconButton
+        testID={INFO_BUTTON}
+        icon='information'
+        iconColor={colors.textSecondary}
+        size={22}
+        style={styles.infoButton}
+        onPress={() => setInfoVisible(true)}
+      />
       <Rotors />
       <Plugboard />
-      <Button
-        onPress={navigateToNextItem}
-        testID={ENCRYPT_MESSAGE_BUTTON}
-        textColor={colors.accent}
-      >
-        {ENCRYPT_MESSAGE}
-      </Button>
+      <View style={styles.bottomRow}>
+        <Button
+          testID={RANDOMIZE_BUTTON}
+          mode='outlined'
+          textColor={colors.textPrimary}
+          style={{ borderColor: colors.border }}
+          onPress={randomizeSettings}
+        >
+          {RANDOMIZE_SETTINGS}
+        </Button>
+        <Button
+          mode='contained'
+          onPress={navigateToNextItem}
+          testID={ENCRYPT_MESSAGE_BUTTON}
+          buttonColor={colors.accent}
+          textColor={colors.background}
+        >
+          {ENCRYPT_MESSAGE}
+        </Button>
+      </View>
       <InfoSidebar
         visible={infoVisible}
         onDismiss={() => setInfoVisible(false)}

--- a/src/components/pages/machine/settings/plugboard/Plugboard.tsx
+++ b/src/components/pages/machine/settings/plugboard/Plugboard.tsx
@@ -29,6 +29,9 @@ export const Plugboard: FunctionComponent = () => {
       </Portal>
       <Button
         testID={ADD_CABLE_MODAL_BUTTON}
+        mode='outlined'
+        textColor={colors.textPrimary}
+        style={{ borderColor: colors.border }}
         onPress={() => setAddCableModalOpen(true)}
       >
         {ADD_CABLE}

--- a/src/components/pages/machine/settings/plugboard/SelectLetterButton.tsx
+++ b/src/components/pages/machine/settings/plugboard/SelectLetterButton.tsx
@@ -1,8 +1,10 @@
 import type { FunctionComponent } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ScrollView, View } from 'react-native';
 import { Button, Text } from 'react-native-paper';
 
+import { makeRotorStyles } from '../../../../../styles';
+import { useThemeColors } from '../../../../../theme/useThemeColors';
 import type { SelectLetterProps } from '../../../../../types';
 
 export const SelectLetterButton: FunctionComponent<SelectLetterProps> = ({
@@ -12,6 +14,9 @@ export const SelectLetterButton: FunctionComponent<SelectLetterProps> = ({
   setAvailableLetters,
   testID,
 }) => {
+  const colors = useThemeColors();
+  const rotorStyles = useMemo(() => makeRotorStyles(colors), [colors]);
+
   const updateLetter = (letter: string) => {
     setLetter(letter);
     setAvailableLetters(
@@ -20,12 +25,15 @@ export const SelectLetterButton: FunctionComponent<SelectLetterProps> = ({
   };
   return (
     <View>
-      <Text>{displayText}</Text>
+      <Text style={rotorStyles.modalText}>{displayText}</Text>
       <ScrollView>
         {availableLetters.map((letter, index) => {
           return (
             <Button
               key={`${letter}${index}`}
+              mode='outlined'
+              textColor={colors.textPrimary}
+              style={{ borderColor: colors.border }}
               onPress={() => updateLetter(letter)}
               testID={`${testID ?? 'test'}${index}`}
             >

--- a/src/components/pages/machine/settings/rotors/ChangeIndexModal.tsx
+++ b/src/components/pages/machine/settings/rotors/ChangeIndexModal.tsx
@@ -44,7 +44,7 @@ export const ChangeIndexModal: FunctionComponent<ChangeIndexModalProps> = ({
       contentContainerStyle={rotorStyles.selectRotor}
     >
       <View>
-        <Text>{SELECT_NEW_LETTER}</Text>
+        <Text style={rotorStyles.modalText}>{SELECT_NEW_LETTER}</Text>
         <ScrollView>
           {currentRotor &&
             currentRotor.config.displayedLetters.map((letter) => {
@@ -52,6 +52,9 @@ export const ChangeIndexModal: FunctionComponent<ChangeIndexModalProps> = ({
                 <Button
                   key={`${letter}${currentRotor.id.toString()}`}
                   testID={letterButton(letter, currentRotor.id)}
+                  mode='outlined'
+                  textColor={colors.textPrimary}
+                  style={{ borderColor: colors.border }}
                   onPress={() => updateIndex(letter)}
                 >
                   {letter}

--- a/src/components/pages/machine/settings/rotors/Rotor.tsx
+++ b/src/components/pages/machine/settings/rotors/Rotor.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { Button, Card, IconButton, Portal } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -33,7 +33,9 @@ interface RotorProps {
 
 export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
   const rotors = useSelector((state: RootState) => state.rotors.available);
-  const [selectedRotorId, setSelectedRotorId] = useState<number | null>(null);
+  const selectedRotorId = useSelector(
+    (state: RootState) => state.rotors.selectedSlots[slotIndex],
+  );
   const selectedRotor =
     selectedRotorId !== null ? (rotors[selectedRotorId] ?? null) : null;
   const [isSelectModalOpen, setIsSelectModalOpen] = useState(false);
@@ -42,7 +44,7 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
   const colors = useThemeColors();
   const rotorStyles = useMemo(() => makeRotorStyles(colors), [colors]);
 
-  const setRotor = () => {
+  const openSelectModal = () => {
     setIsSelectModalOpen(true);
   };
   const removeRotor = () => {
@@ -50,17 +52,13 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
       dispatch(
         updateRotorAvailability({ id: selectedRotor.id, isAvailable: true }),
       );
-    setSelectedRotorId(null);
     dispatch(clearSelectedRotor({ slotIndex }));
   };
   const handleSetRotor = (rotor: RotorState | null) => {
-    setSelectedRotorId(rotor?.id ?? null);
-  };
-  useEffect(() => {
-    if (selectedRotorId !== null) {
-      dispatch(setSelectedRotorAction({ slotIndex, rotorId: selectedRotorId }));
+    if (rotor !== null) {
+      dispatch(setSelectedRotorAction({ slotIndex, rotorId: rotor.id }));
     }
-  }, [dispatch, selectedRotorId, slotIndex]);
+  };
   return (
     <View>
       <Portal>
@@ -90,6 +88,8 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
               )}
               subtitle={currentRotor(selectedRotor.id)}
               style={rotorStyles.cardComponent}
+              titleStyle={{ color: colors.textPrimary }}
+              subtitleStyle={{ color: colors.textSecondary }}
               right={() => (
                 <IconButton
                   testID={REMOVE_ROTOR_BUTTON}
@@ -101,11 +101,20 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
               )}
             />
             <Card.Actions style={rotorStyles.cardComponent}>
-              <Button testID={REPLACE_ROTOR_BUTTON} onPress={setRotor}>
+              <Button
+                testID={REPLACE_ROTOR_BUTTON}
+                mode='outlined'
+                textColor={colors.textPrimary}
+                style={{ borderColor: colors.border }}
+                onPress={openSelectModal}
+              >
                 {REPLACE_ROTOR}
               </Button>
               <Button
                 testID={CHANGE_LETTER_BUTTON}
+                mode='outlined'
+                textColor={colors.textPrimary}
+                style={{ borderColor: colors.border }}
                 onPress={() => setIsChangeIndexModalOpen(true)}
               >
                 {CHANGE_CURRENT_LETTER}
@@ -116,12 +125,15 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
         {selectedRotor === null && (
           <Card.Title
             title={NO_ROTOR_SELECTED}
+            titleStyle={{ color: colors.textPrimary }}
             style={rotorStyles.cardComponent}
             right={() => (
               <Button
                 mode='contained'
                 testID={SET_ROTOR_BUTTON}
-                onPress={setRotor}
+                buttonColor={colors.accent}
+                textColor={colors.background}
+                onPress={openSelectModal}
               >
                 {SELECT_ROTOR}
               </Button>

--- a/src/components/pages/machine/settings/rotors/RotorSelectModal.tsx
+++ b/src/components/pages/machine/settings/rotors/RotorSelectModal.tsx
@@ -43,7 +43,7 @@ export const RotorSelectModal: FunctionComponent<RotorSelectModalProps> = ({
       testID={ROTOR_SELECT_MODAL}
     >
       <View>
-        <Text>{SELECT_ROTOR}</Text>
+        <Text style={rotorStyles.modalText}>{SELECT_ROTOR}</Text>
         {Object.keys(rotors)
           .filter((key) => rotors[parseInt(key)].isAvailable)
           .map((key) => {
@@ -52,6 +52,9 @@ export const RotorSelectModal: FunctionComponent<RotorSelectModalProps> = ({
               <Button
                 key={rotor.id}
                 testID={selectRotorButton(rotor.id)}
+                mode='outlined'
+                textColor={colors.textPrimary}
+                style={{ borderColor: colors.border }}
                 onPress={() => chooseRotor(rotor)}
               >
                 {rotor.id}

--- a/src/constants/labels.tsx
+++ b/src/constants/labels.tsx
@@ -58,6 +58,12 @@ export const SETTINGS_RESET_CONFIRM_MESSAGE =
 export const SETTINGS_RESET_CONFIRM = 'Reset';
 export const SETTINGS_RESET_CANCEL = 'Cancel';
 
+export const RANDOMIZE_SETTINGS = 'Randomize';
+
+export const PASTE_TEXT = 'Feed text';
+export const PASTE_TEXT_PLACEHOLDER = 'Enter text to encrypt / decrypt';
+export const PASTE_CONFIRM = 'Feed';
+
 export const ABOUT_TITLE = 'The Enigma Machine';
 
 export const ABOUT_HISTORY_HEADING = 'History';

--- a/src/constants/selectors.tsx
+++ b/src/constants/selectors.tsx
@@ -32,3 +32,8 @@ export const COPY_MESSAGE_BUTTON = 'copyMessageButton';
 export const INFO_BUTTON = 'infoButton';
 export const INFO_SIDEBAR = 'infoSidebar';
 export const INFO_SIDEBAR_CLOSE = 'infoSidebarClose';
+
+export const RANDOMIZE_BUTTON = 'randomizeButton';
+export const PASTE_TEXT_BUTTON = 'pasteTextButton';
+export const PASTE_TEXT_INPUT = 'pasteTextInput';
+export const PASTE_CONFIRM_BUTTON = 'pasteConfirmButton';

--- a/src/styles/index.tsx
+++ b/src/styles/index.tsx
@@ -32,6 +32,11 @@ export const makeRotorStyles = (colors: ColorPalette) =>
     rotor: {
       marginVertical: 10,
       paddingHorizontal: 0,
+      backgroundColor: colors.surface,
+    },
+    modalText: {
+      color: colors.textPrimary,
+      marginBottom: 8,
     },
     selectRotor: {
       backgroundColor: colors.surface,
@@ -132,5 +137,24 @@ export const makeKeyboardStyles = (colors: ColorPalette) =>
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
+    },
+    headerActions: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    pasteModal: {
+      backgroundColor: colors.surface,
+      margin: 24,
+      padding: 20,
+      borderRadius: 8,
+    },
+    pasteInput: {
+      backgroundColor: colors.surface,
+      marginBottom: 12,
+    },
+    pasteButtonRow: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      gap: 8,
     },
   });


### PR DESCRIPTION
## Summary

- **Light mode fixes** — all buttons in rotor/plugboard settings now use explicit theme colours (`textColor`, `borderColor`, card `backgroundColor`), fixing yellow-on-white text and dark modal backgrounds in light mode
- **Button consistency** — settings page buttons now follow the same outlined/contained convention as the Break Cipher page
- **Info button repositioned** — moved from its own dedicated row to an absolute overlay at the top-right of the Settings screen, freeing up layout space
- **Randomize button** — single tap randomly selects 3 rotors (with random starting positions) and adds 3–5 plugboard cables; refactored `Rotor` to read from Redux state directly so external dispatches update the UI immediately
- **Feed text to keyboard** — clipboard icon in the Keyboard header opens a modal; the full input is processed in one bulk pass through the machine with correct rotor stepping throughout

## Test plan

- [ ] Toggle to light mode and verify rotor cards, modals, and all buttons show correct colours (no yellow text on white, no dark modal backgrounds)
- [ ] Verify Settings buttons match the outlined style of the Break Cipher page
- [ ] Confirm the info button no longer occupies its own row and appears overlaid at the top-right
- [ ] Tap **Randomize** — all 3 rotor slots should fill with random rotors/positions and plugboard cables should appear
- [ ] Tap **Randomize** multiple times — each tap should produce a different configuration
- [ ] On the Keyboard screen, tap the clipboard icon, enter text, tap **Feed** — output and message should update correctly (same result as typing each letter manually)
- [ ] Verify dark mode still looks correct after all changes

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)