### PR TITLE
fix: resolve @react-native-clipboard/clipboard missing from test environment

### DIFF
--- a/__mocks__/@react-native-clipboard/clipboard.js
+++ b/__mocks__/@react-native-clipboard/clipboard.js
@@ -1,0 +1,4 @@
+module.exports = {
+  __esModule: true,
+  default: { setString: jest.fn() },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,11 @@ module.exports = {
       ')/)',
   ],
 
+  moduleNameMapper: {
+    '@react-native-clipboard/clipboard':
+      '<rootDir>/__mocks__/@react-native-clipboard/clipboard.js',
+  },
+
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 
   setupFiles: ['./jest.setup.js'],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -12,11 +12,6 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
 
-jest.mock('@react-native-clipboard/clipboard', () => ({
-  __esModule: true,
-  default: { setString: jest.fn() },
-}));
-
 jest.mock('react-native-paper', () => {
   const RealModule = jest.requireActual('react-native-paper');
   const React = require('react');


### PR DESCRIPTION
## Summary

- `@react-native-clipboard/clipboard` was listed as a dependency in `package.json` but never installed, causing `Cannot find module` in `jest.setup.js` and making all test suites fail to run
- Added a `moduleNameMapper` entry in `jest.config.js` that points Jest to a manual mock in `__mocks__/@react-native-clipboard/clipboard.js`, resolving the module without requiring the native package to be installed
- Removed the now-redundant `jest.mock()` call from `jest.setup.js`

## Test plan

- [ ] Run `npm test` — all 20 suites (114 tests) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)