### PR TITLE
feat: add Maestro E2E smoke tests and manual CI workflow

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,54 @@
+name: E2E Smoke Tests
+
+# workflow_dispatch is restricted to users with write access to this repo.
+# On a public repo this means only collaborators can trigger this workflow.
+on:
+  workflow_dispatch:
+
+jobs:
+  e2e-android:
+    name: Android Smoke Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup project
+        uses: ./.github/actions/setup
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('android/gradle/wrapper/gradle-wrapper.properties', 'android/build.gradle') }}
+          restore-keys: gradle-
+
+      - name: Build debug APK
+        run: cd android && ./gradlew assembleDebug --no-daemon
+
+      - name: Run smoke tests on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          arch: x86_64
+          disable-animations: true
+          script: |
+            adb install android/app/build/outputs/apk/debug/app-debug.apk
+            adb reverse tcp:8081 tcp:8081
+            npx react-native start --reset-cache &
+            until curl -s http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done
+            maestro test e2e/smoke/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,62 @@
+# E2E Smoke Tests
+
+Lightweight smoke tests using [Maestro](https://maestro.mobile.dev/) to verify core navigation flows on a real device or simulator. No code changes or build step required — runs against a Metro dev build.
+
+## Prerequisites
+
+Install the Maestro CLI:
+
+```bash
+curl -Ls "https://get.maestro.mobile.dev" | bash
+```
+
+Verify the installation:
+
+```bash
+maestro --version
+```
+
+## Running the tests
+
+1. Build and launch the app on a connected device or simulator:
+
+```bash
+# Android
+npm run android
+
+# iOS
+npm run ios
+```
+
+2. Run all smoke tests:
+
+```bash
+npm run test:e2e:smoke
+```
+
+Or run a single flow:
+
+```bash
+maestro test e2e/smoke/app-launch.yaml
+```
+
+## Flows
+
+| File | What it verifies |
+|---|---|
+| `smoke/app-launch.yaml` | App launches and the Machine screen is visible |
+| `smoke/navigate-break-cipher.yaml` | Drawer opens and navigates to Break Cipher |
+| `smoke/navigate-about.yaml` | Drawer opens and navigates to About |
+| `smoke/navigate-settings.yaml` | Drawer opens and navigates to Settings |
+
+## Element selectors
+
+Flows use `testID` constants from `src/constants/selectors.tsx` as element IDs (via Maestro's `id` selector). Text assertions use the screen header titles defined in `src/App.tsx`.
+
+## iOS app ID
+
+For iOS, update `appId` in each YAML file to:
+
+```
+org.reactjs.native.example.EnigmaProject
+```

--- a/e2e/smoke/app-launch.yaml
+++ b/e2e/smoke/app-launch.yaml
@@ -1,0 +1,6 @@
+appId: com.enigmaproject
+---
+- launchApp
+- assertVisible: "Enigma machine"
+- assertVisible:
+    id: "goToKeyboardButton"

--- a/e2e/smoke/navigate-about.yaml
+++ b/e2e/smoke/navigate-about.yaml
@@ -1,0 +1,7 @@
+appId: com.enigmaproject
+---
+- launchApp
+- tapOn:
+    label: "Open drawer"
+- tapOn: "About Enigma"
+- assertVisible: "About Enigma"

--- a/e2e/smoke/navigate-break-cipher.yaml
+++ b/e2e/smoke/navigate-break-cipher.yaml
@@ -1,0 +1,9 @@
+appId: com.enigmaproject
+---
+- launchApp
+- tapOn:
+    label: "Open drawer"
+- tapOn: "Break a cipher"
+- assertVisible: "Break a cipher"
+- assertVisible:
+    id: "ciphertextInput"

--- a/e2e/smoke/navigate-settings.yaml
+++ b/e2e/smoke/navigate-settings.yaml
@@ -1,0 +1,7 @@
+appId: com.enigmaproject
+---
+- launchApp
+- tapOn:
+    label: "Open drawer"
+- tapOn: "Settings"
+- assertVisible: "Settings"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:fix": "tsc --noEmit && eslint --fix .",
     "start": "react-native start",
     "test": "jest",
+    "test:e2e:smoke": "maestro test e2e/smoke/",
     "prettier": "prettier src/**/*.{ts,tsx}",
     "prettier:fix": "prettier --write src/**/*.{ts,tsx}",
     "format": "npm run prettier:fix && npm run lint:fix",


### PR DESCRIPTION
## Summary

- Adds four Maestro YAML smoke tests covering core navigation flows (app launch, Break Cipher, About, Settings)
- Adds a manual `workflow_dispatch` GitHub Actions workflow to run the tests on an Android emulator in CI — restricted to collaborators with write access by default
- Adds `test:e2e:smoke` script to `package.json` for running locally
- Adds `e2e/README.md` with setup and usage instructions

Closes #67

## Test plan

- [ ] Install Maestro CLI (`curl -Ls "https://get.maestro.mobile.dev" | bash`)
- [ ] Build and install the debug APK on a connected device/emulator
- [ ] Start Metro (`npm run start`)
- [ ] Run `npm run test:e2e:smoke` and verify all 4 flows pass
- [ ] Confirm the Actions workflow is visible under Actions → E2E Smoke Tests with a "Run workflow" button (write-access only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)