### PR TITLE
fix: add chmod to gradlew before Android build in E2E workflow

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -38,7 +38,9 @@ jobs:
           restore-keys: gradle-
 
       - name: Build debug APK
-        run: cd android && ./gradlew assembleDebug --no-daemon
+        run: |
+          chmod +x android/gradlew
+          cd android && ./gradlew assembleDebug --no-daemon
 
       - name: Run smoke tests on Android emulator
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
## Summary

The E2E smoke test workflow was failing at the **Build debug APK** step with `Permission denied` (exit code 126) because `gradlew` wasn't committed with execute permissions.

Added `chmod +x android/gradlew` before the Gradle invocation.

## Related

Fixes the failure in https://github.com/samdaw13/EnigmaProject/actions/runs/22771680070/job/66054124598

🤖 Generated with [Claude Code](https://claude.com/claude-code)