### PR TITLE
feat: remove brute force search

### DIFF
--- a/src/components/pages/breakCipher/BreakCipher.test.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.test.tsx
@@ -1,30 +1,19 @@
 import React from 'react';
 
-import { CIPHERTEXT_TOO_LONG } from '../../../constants/labels';
 import {
   BRUTE_FORCE_RESULT_CARD,
-  BRUTE_FORCE_TAB_BUTTON,
   CANCEL_SEARCH_BUTTON,
   CIPHERTEXT_INPUT,
   COPY_MESSAGE_BUTTON,
-  CRIB_ANALYSIS_TAB_BUTTON,
   CRIB_INPUT,
   CRIB_POSITION_CARD,
   DECRYPTED_TEXT_DISPLAY,
-  NLP_SCORE_DISPLAY,
-  PLAINTEXT_INPUT,
   PROGRESS_BAR,
   RESULTS_CONTAINER,
   RUN_ANALYSIS_BUTTON,
 } from '../../../constants/selectors';
-import type {
-  BruteForceResult,
-  CribSearchResult,
-} from '../../../utils/codebreaking';
-import {
-  bruteForceSearchAsync,
-  cribSearchAsync,
-} from '../../../utils/codebreaking';
+import type { CribSearchResult } from '../../../utils/codebreaking';
+import { cribSearchAsync } from '../../../utils/codebreaking';
 import {
   act,
   fireEvent,
@@ -38,27 +27,6 @@ jest.mock('../../../utils/codebreaking', () => {
   const actual = jest.requireActual<object>('../../../utils/codebreaking');
   return {
     ...actual,
-    bruteForceSearchAsync: jest.fn(
-      (
-        _ciphertext: string,
-        _plaintext: string | undefined,
-        _rotors: object,
-        _reflectors: object,
-        onProgress: (p: number) => void,
-      ) => {
-        onProgress(0.5);
-        onProgress(1);
-        return Promise.resolve([
-          {
-            rotorIds: [3, 2, 1],
-            reflectorName: 'UKW-B',
-            startingPositions: [0, 0, 0],
-            decryptedText: 'HELLO',
-            nlpScore: 75,
-          },
-        ]);
-      },
-    ),
     cribSearchAsync: jest.fn(
       (
         _ciphertext: string,
@@ -74,39 +42,20 @@ jest.mock('../../../utils/codebreaking', () => {
   };
 });
 
-const mockBruteForceSearchAsync = bruteForceSearchAsync as jest.MockedFunction<
-  typeof bruteForceSearchAsync
->;
 const mockCribSearchAsync = cribSearchAsync as jest.MockedFunction<
   typeof cribSearchAsync
 >;
 
 describe('BreakCipher', () => {
-  it('renders the brute force tab by default', async () => {
+  it('renders the crib analysis interface', async () => {
     await render(<BreakCipher />);
     expect(screen.getByTestId(CIPHERTEXT_INPUT)).toBeTruthy();
-    expect(screen.getByTestId(PLAINTEXT_INPUT)).toBeTruthy();
-    expect(screen.getByTestId(RUN_ANALYSIS_BUTTON)).toBeTruthy();
-  });
-
-  it('switches to crib analysis tab', async () => {
-    await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
     expect(screen.getByTestId(CRIB_INPUT)).toBeTruthy();
-    expect(screen.queryByTestId(PLAINTEXT_INPUT)).toBeNull();
-  });
-
-  it('switches back to brute force tab', async () => {
-    await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
-    await fireEvent.press(screen.getByTestId(BRUTE_FORCE_TAB_BUTTON));
-    expect(screen.getByTestId(PLAINTEXT_INPUT)).toBeTruthy();
-    expect(screen.queryByTestId(CRIB_INPUT)).toBeNull();
+    expect(screen.getByTestId(RUN_ANALYSIS_BUTTON)).toBeTruthy();
   });
 
   it('runs crib analysis and displays structural fallback when cribSearchAsync returns empty', async () => {
     await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
 
     await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
     await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
@@ -117,24 +66,12 @@ describe('BreakCipher', () => {
     });
   });
 
-  it('runs brute force and displays results', async () => {
-    await render(<BreakCipher />);
-
-    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABC');
-    await fireEvent.changeText(screen.getByTestId(PLAINTEXT_INPUT), 'XYZ');
-    await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
-
-    await waitFor(() => {
-      expect(screen.getByTestId(RESULTS_CONTAINER)).toBeTruthy();
-    });
-  });
-
-  it('shows progress bar during brute force search', async () => {
-    let resolveSearch!: (value: BruteForceResult[]) => void;
-    mockBruteForceSearchAsync.mockImplementationOnce(
+  it('shows progress bar during crib search', async () => {
+    let resolveSearch!: (value: CribSearchResult[]) => void;
+    mockCribSearchAsync.mockImplementationOnce(
       (
         _c: string,
-        _p: string | undefined,
+        _cr: string,
         _r: object,
         _ref: object,
         onProgress: (p: number) => void,
@@ -148,8 +85,8 @@ describe('BreakCipher', () => {
 
     await render(<BreakCipher />);
 
-    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABC');
-    await fireEvent.changeText(screen.getByTestId(PLAINTEXT_INPUT), 'XYZ');
+    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
+    await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
     await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
 
     await waitFor(() => {
@@ -162,10 +99,10 @@ describe('BreakCipher', () => {
   });
 
   it('cancel button stops search and hides progress bar', async () => {
-    mockBruteForceSearchAsync.mockImplementationOnce(
+    mockCribSearchAsync.mockImplementationOnce(
       (
         _c: string,
-        _p: string | undefined,
+        _cr: string,
         _r: object,
         _ref: object,
         onProgress: (p: number) => void,
@@ -179,8 +116,8 @@ describe('BreakCipher', () => {
 
     await render(<BreakCipher />);
 
-    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABC');
-    await fireEvent.changeText(screen.getByTestId(PLAINTEXT_INPUT), 'XYZ');
+    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
+    await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
     await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
 
     await waitFor(() => {
@@ -192,32 +129,6 @@ describe('BreakCipher', () => {
     await waitFor(() => {
       expect(screen.queryByTestId(PROGRESS_BAR)).toBeNull();
       expect(screen.queryByTestId(CANCEL_SEARCH_BUTTON)).toBeNull();
-    });
-  });
-
-  it('brute force result card shows decrypted text and NLP score', async () => {
-    await render(<BreakCipher />);
-
-    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABC');
-    await fireEvent.changeText(screen.getByTestId(PLAINTEXT_INPUT), 'XYZ');
-    await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
-
-    await waitFor(() => {
-      expect(screen.getByTestId(`${BRUTE_FORCE_RESULT_CARD}_0`)).toBeTruthy();
-      expect(screen.getByTestId(`${DECRYPTED_TEXT_DISPLAY}_0`)).toBeTruthy();
-      expect(screen.getByTestId(`${NLP_SCORE_DISPLAY}_0`)).toBeTruthy();
-    });
-  });
-
-  it('brute force result card shows copy button for decrypted text', async () => {
-    await render(<BreakCipher />);
-
-    await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABC');
-    await fireEvent.changeText(screen.getByTestId(PLAINTEXT_INPUT), 'XYZ');
-    await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
-
-    await waitFor(() => {
-      expect(screen.getByTestId(`${COPY_MESSAGE_BUTTON}_0`)).toBeTruthy();
     });
   });
 
@@ -245,7 +156,6 @@ describe('BreakCipher', () => {
     );
 
     await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
 
     await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
     await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
@@ -281,7 +191,6 @@ describe('BreakCipher', () => {
     );
 
     await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
 
     await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
     await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
@@ -294,7 +203,6 @@ describe('BreakCipher', () => {
 
   it('expands crib position card on press in structural fallback', async () => {
     await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
 
     await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
     await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
@@ -314,7 +222,6 @@ describe('BreakCipher', () => {
 
   it('collapses crib position card on second press', async () => {
     await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
 
     await fireEvent.changeText(screen.getByTestId(CIPHERTEXT_INPUT), 'ABCDEF');
     await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'XY');
@@ -333,22 +240,6 @@ describe('BreakCipher', () => {
     ).toBeNull();
   });
 
-  it('Run button is disabled and shows error when no plaintext and ciphertext exceeds 50 chars', async () => {
-    await render(<BreakCipher />);
-
-    mockBruteForceSearchAsync.mockClear();
-
-    await fireEvent.changeText(
-      screen.getByTestId(CIPHERTEXT_INPUT),
-      'A'.repeat(51),
-    );
-
-    expect(screen.getByText(CIPHERTEXT_TOO_LONG)).toBeTruthy();
-
-    await fireEvent.press(screen.getByTestId(RUN_ANALYSIS_BUTTON));
-    expect(mockBruteForceSearchAsync).not.toHaveBeenCalled();
-  });
-
   it('sanitizes ciphertext input to uppercase alpha only', async () => {
     await render(<BreakCipher />);
     await fireEvent.changeText(
@@ -358,20 +249,8 @@ describe('BreakCipher', () => {
     expect(screen.getByTestId(CIPHERTEXT_INPUT).props['value']).toBe('ABC');
   });
 
-  it('sanitizes plaintext input to uppercase alpha only', async () => {
-    await render(<BreakCipher />);
-    await fireEvent.changeText(
-      screen.getByTestId(PLAINTEXT_INPUT),
-      'hello world',
-    );
-    expect(screen.getByTestId(PLAINTEXT_INPUT).props['value']).toBe(
-      'HELLOWORLD',
-    );
-  });
-
   it('sanitizes crib input to uppercase alpha only', async () => {
     await render(<BreakCipher />);
-    await fireEvent.press(screen.getByTestId(CRIB_ANALYSIS_TAB_BUTTON));
     await fireEvent.changeText(screen.getByTestId(CRIB_INPUT), 'cr1b!');
     expect(screen.getByTestId(CRIB_INPUT).props['value']).toBe('CRB');
   });

--- a/src/components/pages/breakCipher/BreakCipher.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.tsx
@@ -1,32 +1,19 @@
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import {
-  Button,
-  IconButton,
-  SegmentedButtons,
-  TextInput,
-} from 'react-native-paper';
+import { Button, IconButton, TextInput } from 'react-native-paper';
 
 import {
-  BRUTE_FORCE_TAB,
   CANCEL_LABEL,
   CIPHERTEXT_LABEL,
-  CIPHERTEXT_TOO_LONG,
   COMMON_CRIBS_HINT,
-  CRIB_ANALYSIS_TAB,
   CRIB_LABEL,
   DECRYPTED_TEXT_LABEL,
   DERIVED_PLUGBOARD_LABEL,
-  INFO_BRUTE_FORCE_CONTENT,
-  INFO_BRUTE_FORCE_TITLE,
   INFO_CRIB_ANALYSIS_CONTENT,
   INFO_CRIB_ANALYSIS_TITLE,
-  KNOWN_PLAINTEXT_LABEL,
-  KNOWN_PLAINTEXT_OPTIONAL_HINT,
   NLP_CONFIDENCE_LABEL,
   NO_CRIB_RESULTS_FALLBACK,
-  NO_RESULTS,
   POSITION_LABEL,
   POSITIONS_LABEL,
   RANKING_RESULTS_LABEL,
@@ -40,17 +27,14 @@ import {
 } from '../../../constants/labels';
 import {
   BRUTE_FORCE_RESULT_CARD,
-  BRUTE_FORCE_TAB_BUTTON,
   CANCEL_SEARCH_BUTTON,
   CIPHERTEXT_INPUT,
   COPY_MESSAGE_BUTTON,
-  CRIB_ANALYSIS_TAB_BUTTON,
   CRIB_INPUT,
   CRIB_POSITION_CARD,
   DECRYPTED_TEXT_DISPLAY,
   INFO_BUTTON,
   NLP_SCORE_DISPLAY,
-  PLAINTEXT_INPUT,
   PROGRESS_BAR,
   RESULTS_CONTAINER,
   RUN_ANALYSIS_BUTTON,
@@ -59,22 +43,15 @@ import { initialReflectorState } from '../../../features/reflector';
 import { initialRotorState } from '../../../features/rotors/features';
 import type { ColorPalette } from '../../../theme/colors';
 import { useThemeColors } from '../../../theme/useThemeColors';
-import type {
-  BruteForceResult,
-  CribSearchResult,
-} from '../../../utils/codebreaking';
+import type { CribSearchResult } from '../../../utils/codebreaking';
 import {
-  bruteForceSearchAsync,
   cribSearchAsync,
   findCribPositions,
 } from '../../../utils/codebreaking';
 import { CopyButton } from '../../common';
 import { InfoSidebar } from '../../InfoSidebar';
 
-type Tab = 'bruteForce' | 'cribAnalysis';
-
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const BRUTE_FORCE_MAX_KEYLESS_LENGTH = 50;
 
 const sanitizeInput = (text: string): string =>
   text
@@ -297,47 +274,6 @@ const RunButton: FunctionComponent<{
   );
 };
 
-const BruteForceResults: FunctionComponent<{
-  results: BruteForceResult[];
-}> = ({ results }) => {
-  const colors = useThemeColors();
-  const styles = useMemo(() => makeStyles(colors), [colors]);
-  return (
-    <View>
-      <Text style={styles.resultsTitle}>{RESULTS_TITLE}</Text>
-      {results.map((result, index) => (
-        <View
-          key={`${result.rotorIds.join('-')}-${result.reflectorName}-${result.startingPositions.join('-')}`}
-          testID={`${BRUTE_FORCE_RESULT_CARD}_${index}`}
-          style={styles.resultCard}
-        >
-          <Text style={styles.resultText}>
-            {ROTOR_ORDER_LABEL}: {result.rotorIds.join(', ')}
-          </Text>
-          <Text style={styles.resultText}>
-            {REFLECTOR_LABEL}: {result.reflectorName}
-          </Text>
-          <Text style={styles.resultText}>
-            {POSITIONS_LABEL}:{' '}
-            {result.startingPositions.map((p) => ALPHABET[p]).join(', ')}
-          </Text>
-          <Text
-            testID={`${DECRYPTED_TEXT_DISPLAY}_${index}`}
-            style={styles.resultText}
-          >
-            {DECRYPTED_TEXT_LABEL}: {result.decryptedText}
-          </Text>
-          <NlpBadge score={result.nlpScore} testIdSuffix={String(index)} />
-          <CopyButton
-            text={result.decryptedText}
-            testID={`${COPY_MESSAGE_BUTTON}_${index}`}
-          />
-        </View>
-      ))}
-    </View>
-  );
-};
-
 const CribSearchResults: FunctionComponent<{
   results: CribSearchResult[];
 }> = ({ results }) => {
@@ -427,14 +363,9 @@ const CribStructuralFallback: FunctionComponent<{
 };
 
 export const BreakCipher: FunctionComponent = () => {
-  const [activeTab, setActiveTab] = useState<Tab>('bruteForce');
   const [infoVisible, setInfoVisible] = useState(false);
   const [ciphertext, setCiphertext] = useState('');
-  const [plaintext, setPlaintext] = useState('');
   const [crib, setCrib] = useState('');
-  const [bruteForceResults, setBruteForceResults] = useState<
-    BruteForceResult[] | null
-  >(null);
   const [cribSearchResults, setCribSearchResults] = useState<
     CribSearchResult[] | null
   >(null);
@@ -454,43 +385,6 @@ export const BreakCipher: FunctionComponent = () => {
     setIsSearching(false);
     setProgress(0);
   }, []);
-
-  const handleTabChange = useCallback((value: string) => {
-    cancelledRef.current = true;
-    setIsSearching(false);
-    setActiveTab(value as Tab);
-    setBruteForceResults(null);
-    setCribSearchResults(null);
-    setLastCribSearch(null);
-    setProgress(0);
-    setExpandedPosition(null);
-  }, []);
-
-  const runBruteForce = useCallback(async () => {
-    const sanitizedCiphertext = sanitizeInput(ciphertext);
-    if (!sanitizedCiphertext) return;
-
-    cancelledRef.current = false;
-    setIsSearching(true);
-    setBruteForceResults(null);
-    setProgress(0);
-
-    const sanitizedPlaintext =
-      plaintext.length > 0 ? sanitizeInput(plaintext) : undefined;
-
-    const results = await bruteForceSearchAsync(
-      sanitizedCiphertext,
-      sanitizedPlaintext,
-      initialRotorState.available,
-      initialReflectorState.reflectors,
-      setProgress,
-      () => cancelledRef.current,
-    );
-    const wasCancelled = cancelledRef.current as boolean;
-    if (wasCancelled) return;
-    setBruteForceResults(results);
-    setIsSearching(false);
-  }, [ciphertext, plaintext]);
 
   const runCribAnalysis = useCallback(async () => {
     const sanitizedCiphertext = sanitizeInput(ciphertext);
@@ -520,12 +414,8 @@ export const BreakCipher: FunctionComponent = () => {
   }, [ciphertext, crib]);
 
   const handleRun = useCallback(() => {
-    if (activeTab === 'bruteForce') {
-      void runBruteForce();
-    } else {
-      void runCribAnalysis();
-    }
-  }, [activeTab, runBruteForce, runCribAnalysis]);
+    void runCribAnalysis();
+  }, [runCribAnalysis]);
 
   const toggleExpandedPosition = useCallback(
     (pos: number) => {
@@ -535,44 +425,8 @@ export const BreakCipher: FunctionComponent = () => {
   );
 
   const sanitizedCiphertextLength = sanitizeInput(ciphertext).length;
-  const isBruteForceWithoutPlaintext =
-    activeTab === 'bruteForce' && plaintext.length === 0;
-  const ciphertextTooLong =
-    isBruteForceWithoutPlaintext &&
-    sanitizedCiphertextLength > BRUTE_FORCE_MAX_KEYLESS_LENGTH;
-
-  const isBruteForceReady =
-    activeTab === 'bruteForce' && sanitizedCiphertextLength > 0;
-  const isCribReady =
-    activeTab === 'cribAnalysis' &&
-    sanitizedCiphertextLength > 0 &&
-    crib.length > 0;
-  const areInputsEmpty = !isBruteForceReady && !isCribReady;
-  const runAnalysisButtonDisabled =
-    areInputsEmpty || isSearching || ciphertextTooLong;
-
-  const hasResults =
-    activeTab === 'bruteForce'
-      ? bruteForceResults !== null
-      : cribSearchResults !== null;
-  const hasNoResults =
-    activeTab === 'bruteForce' &&
-    bruteForceResults !== null &&
-    bruteForceResults.length === 0;
-
-  const hintText =
-    activeTab === 'bruteForce'
-      ? KNOWN_PLAINTEXT_OPTIONAL_HINT
-      : COMMON_CRIBS_HINT;
-
-  const infoTitle =
-    activeTab === 'bruteForce'
-      ? INFO_BRUTE_FORCE_TITLE
-      : INFO_CRIB_ANALYSIS_TITLE;
-  const infoContent =
-    activeTab === 'bruteForce'
-      ? INFO_BRUTE_FORCE_CONTENT
-      : INFO_CRIB_ANALYSIS_CONTENT;
+  const isCribReady = sanitizedCiphertextLength > 0 && crib.length > 0;
+  const runAnalysisButtonDisabled = !isCribReady || isSearching;
 
   return (
     <ScrollView style={styles.screen}>
@@ -585,31 +439,6 @@ export const BreakCipher: FunctionComponent = () => {
           onPress={() => setInfoVisible(true)}
         />
       </View>
-      <SegmentedButtons
-        value={activeTab}
-        onValueChange={handleTabChange}
-        buttons={[
-          {
-            value: 'bruteForce',
-            label: BRUTE_FORCE_TAB,
-            testID: BRUTE_FORCE_TAB_BUTTON,
-          },
-          {
-            value: 'cribAnalysis',
-            label: CRIB_ANALYSIS_TAB,
-            testID: CRIB_ANALYSIS_TAB_BUTTON,
-          },
-        ]}
-        style={styles.tabs}
-        theme={{
-          colors: {
-            secondaryContainer: colors.surfaceAlt,
-            onSecondaryContainer: colors.accent,
-            onSurface: colors.textSecondary,
-            outline: colors.border,
-          },
-        }}
-      />
 
       <TextInput
         testID={CIPHERTEXT_INPUT}
@@ -625,41 +454,21 @@ export const BreakCipher: FunctionComponent = () => {
         theme={{ colors: { onSurfaceVariant: colors.textSecondary } }}
       />
 
-      {activeTab === 'bruteForce' ? (
-        <TextInput
-          testID={PLAINTEXT_INPUT}
-          label={KNOWN_PLAINTEXT_LABEL}
-          value={plaintext}
-          onChangeText={(text) => setPlaintext(sanitizeInput(text))}
-          mode='outlined'
-          autoCapitalize='characters'
-          style={styles.input}
-          textColor={colors.textPrimary}
-          outlineColor={colors.border}
-          activeOutlineColor={colors.accent}
-          theme={{ colors: { onSurfaceVariant: colors.textSecondary } }}
-        />
-      ) : (
-        <TextInput
-          testID={CRIB_INPUT}
-          label={CRIB_LABEL}
-          value={crib}
-          onChangeText={(text) => setCrib(sanitizeInput(text))}
-          mode='outlined'
-          autoCapitalize='characters'
-          style={styles.input}
-          textColor={colors.textPrimary}
-          outlineColor={colors.border}
-          activeOutlineColor={colors.accent}
-          theme={{ colors: { onSurfaceVariant: colors.textSecondary } }}
-        />
-      )}
+      <TextInput
+        testID={CRIB_INPUT}
+        label={CRIB_LABEL}
+        value={crib}
+        onChangeText={(text) => setCrib(sanitizeInput(text))}
+        mode='outlined'
+        autoCapitalize='characters'
+        style={styles.input}
+        textColor={colors.textPrimary}
+        outlineColor={colors.border}
+        activeOutlineColor={colors.accent}
+        theme={{ colors: { onSurfaceVariant: colors.textSecondary } }}
+      />
 
-      <Text style={styles.hintText}>{hintText}</Text>
-
-      {ciphertextTooLong && (
-        <Text style={styles.errorText}>{CIPHERTEXT_TOO_LONG}</Text>
-      )}
+      <Text style={styles.hintText}>{COMMON_CRIBS_HINT}</Text>
 
       <RunButton
         isSearching={isSearching}
@@ -680,39 +489,27 @@ export const BreakCipher: FunctionComponent = () => {
         </Button>
       )}
 
-      {hasResults && !isSearching && (
-        <View testID={RESULTS_CONTAINER}>
-          {hasNoResults && <Text style={styles.noResults}>{NO_RESULTS}</Text>}
-
-          {activeTab === 'bruteForce' &&
-            bruteForceResults &&
-            bruteForceResults.length > 0 && (
-              <BruteForceResults results={bruteForceResults} />
+      {cribSearchResults !== null &&
+        !isSearching &&
+        lastCribSearch !== null && (
+          <View testID={RESULTS_CONTAINER}>
+            {cribSearchResults.length > 0 ? (
+              <CribSearchResults results={cribSearchResults} />
+            ) : (
+              <CribStructuralFallback
+                ciphertext={lastCribSearch.ciphertext}
+                crib={lastCribSearch.crib}
+                expandedPosition={expandedPosition}
+                onTogglePosition={toggleExpandedPosition}
+              />
             )}
-
-          {activeTab === 'cribAnalysis' &&
-            cribSearchResults !== null &&
-            lastCribSearch !== null && (
-              <>
-                {cribSearchResults.length > 0 ? (
-                  <CribSearchResults results={cribSearchResults} />
-                ) : (
-                  <CribStructuralFallback
-                    ciphertext={lastCribSearch.ciphertext}
-                    crib={lastCribSearch.crib}
-                    expandedPosition={expandedPosition}
-                    onTogglePosition={toggleExpandedPosition}
-                  />
-                )}
-              </>
-            )}
-        </View>
-      )}
+          </View>
+        )}
       <InfoSidebar
         visible={infoVisible}
         onDismiss={() => setInfoVisible(false)}
-        title={infoTitle}
-        content={infoContent}
+        title={INFO_CRIB_ANALYSIS_TITLE}
+        content={INFO_CRIB_ANALYSIS_CONTENT}
       />
     </ScrollView>
   );

--- a/src/constants/labels.tsx
+++ b/src/constants/labels.tsx
@@ -13,10 +13,8 @@ export const COPY_MESSAGE = 'Copy';
 export const COPIED_MESSAGE = 'Copied!';
 
 export const BREAK_CIPHER_TITLE = 'Break Cipher';
-export const BRUTE_FORCE_TAB = 'Brute Force';
 export const CRIB_ANALYSIS_TAB = 'Crib Analysis';
 export const CIPHERTEXT_LABEL = 'Ciphertext';
-export const KNOWN_PLAINTEXT_LABEL = 'Known plaintext';
 export const CRIB_LABEL = 'Crib (suspected word)';
 export const RUN_ANALYSIS = 'Run';
 export const RUNNING_ANALYSIS = 'Running...';
@@ -28,19 +26,12 @@ export const REFLECTOR_LABEL = 'Reflector';
 export const POSITIONS_LABEL = 'Positions';
 export const VALID_POSITIONS_LABEL = 'Valid crib positions';
 export const POSITION_LABEL = 'Position';
-export const KNOWN_PLAINTEXT_HINT =
-  'Both methods require some known or suspected plaintext';
-export const KNOWN_PLAINTEXT_OPTIONAL_HINT =
-  'Known plaintext is optional — omit to search all combinations (ciphertext ≤ 50 chars)';
 export const COMMON_CRIBS_HINT = 'Common cribs: WETTER, KEINE, OBERKOMMANDO';
-export const CRIB_SEARCH_HINT = 'Common cribs: WETTER, KEINE, OBERKOMMANDO';
 export const TAP_TO_EXPAND = 'Tap a position to see alignment';
 export const DECRYPTED_TEXT_LABEL = 'Decrypted';
 export const NLP_CONFIDENCE_LABEL = 'Confidence';
 export const NO_CRIB_RESULTS_FALLBACK =
   'No configurations found — showing structural positions only';
-export const CIPHERTEXT_TOO_LONG =
-  'Ciphertext must be 50 characters or fewer for keyless brute force';
 export const RANKING_RESULTS_LABEL = 'Search complete, ranking results...';
 export const CANCEL_LABEL = 'Cancel';
 export const DERIVED_PLUGBOARD_LABEL = 'Plugboard';
@@ -79,10 +70,6 @@ export const ABOUT_HOW_IT_WORKS_BODY =
 export const ABOUT_CODEBREAKERS_HEADING = 'The Codebreakers';
 export const ABOUT_CODEBREAKERS_BODY =
   'Breaking Enigma was a collaborative effort spanning decades. Polish mathematician Marian Rejewski first cracked early Enigma variants in the 1930s using mathematical analysis, sharing his work with British and French intelligence shortly before the war.\n\nAt Bletchley Park, Alan Turing and Gordon Welchman improved on the Polish "Bomba" to create the electromechanical Bombe, a machine that could systematically eliminate incorrect Enigma settings. By exploiting predictable message structures — known as "cribs" — codebreakers could narrow down millions of possible configurations in hours.\n\nThe intelligence produced, codenamed ULTRA, is widely credited with shortening the war by two to four years.';
-
-export const INFO_BRUTE_FORCE_TITLE = 'Brute Force';
-export const INFO_BRUTE_FORCE_CONTENT =
-  'Brute force tests every combination of rotors, reflector, and starting positions against your ciphertext.\n\nOptional: if you know a word or phrase that appears in the plaintext, enter it as known plaintext. This dramatically narrows the search.\n\nWithout known plaintext, the ciphertext must be 50 characters or fewer. Results are ranked by NLP confidence — a measure of how closely the decrypted text resembles natural English.';
 
 export const INFO_CRIB_ANALYSIS_TITLE = 'Crib Analysis';
 export const INFO_CRIB_ANALYSIS_CONTENT =

--- a/src/utils/codebreaking.test.tsx
+++ b/src/utils/codebreaking.test.tsx
@@ -5,14 +5,8 @@ import type {
   ReflectorState,
   RotorState,
 } from '../types/interfaces';
-import type {
-  BruteForceResult,
-  CribSearchResult,
-  MenuEdge,
-} from './codebreaking';
+import type { CribSearchResult, MenuEdge } from './codebreaking';
 import {
-  bruteForceSearch,
-  bruteForceSearchAsync,
   buildMenuEdges,
   cribSearchAsync,
   encryptString,
@@ -66,118 +60,6 @@ describe('encryptString', () => {
     const result = encryptString(plaintext, rotors, emptyPlugboard, reflectorB);
     for (let i = 0; i < plaintext.length; i++) {
       expect(result[i]).not.toBe(plaintext[i]);
-    }
-  });
-});
-
-describe('bruteForceSearch', () => {
-  it('finds the correct configuration for a known pair', () => {
-    const rotors = [
-      { ...rotorIII, config: { ...rotorIII.config, currentIndex: 0 } },
-      { ...rotorII, config: { ...rotorII.config, currentIndex: 0 } },
-      { ...rotorI, config: { ...rotorI.config, currentIndex: 0 } },
-    ];
-    const plaintext = 'HI';
-    const ciphertext = encryptString(
-      plaintext,
-      rotors,
-      emptyPlugboard,
-      reflectorB,
-    );
-
-    const results: BruteForceResult[] = bruteForceSearch(
-      ciphertext,
-      plaintext,
-      initialRotorState.available,
-      { 2: initialReflectorState.reflectors[2]! },
-    );
-
-    const matchingResult = results.find(
-      (r) =>
-        r.rotorIds[0] === 3 &&
-        r.rotorIds[1] === 2 &&
-        r.rotorIds[2] === 1 &&
-        r.startingPositions[0] === 0 &&
-        r.startingPositions[1] === 0 &&
-        r.startingPositions[2] === 0,
-    );
-    expect(matchingResult).toBeDefined();
-    expect(matchingResult!.reflectorName).toBe('UKW-B');
-    expect(matchingResult!.decryptedText).toBeTruthy();
-    expect(matchingResult!.nlpScore).toBeGreaterThanOrEqual(0);
-    expect(matchingResult!.nlpScore).toBeLessThanOrEqual(100);
-  });
-
-  it('returns empty array when no config matches', () => {
-    const results = bruteForceSearch(
-      'ZZ',
-      'ZZ',
-      initialRotorState.available,
-      initialReflectorState.reflectors,
-    );
-    expect(results).toEqual([]);
-  });
-});
-
-describe('bruteForceSearchAsync', () => {
-  it('finds the same results as synchronous version', async () => {
-    jest.useRealTimers();
-    const rotors = [
-      { ...rotorIII, config: { ...rotorIII.config, currentIndex: 0 } },
-      { ...rotorII, config: { ...rotorII.config, currentIndex: 0 } },
-      { ...rotorI, config: { ...rotorI.config, currentIndex: 0 } },
-    ];
-    const plaintext = 'HI';
-    const ciphertext = encryptString(
-      plaintext,
-      rotors,
-      emptyPlugboard,
-      reflectorB,
-    );
-
-    const singleReflector = { 2: initialReflectorState.reflectors[2]! };
-    const progressValues: number[] = [];
-
-    const results = await bruteForceSearchAsync(
-      ciphertext,
-      plaintext,
-      initialRotorState.available,
-      singleReflector,
-      (p) => progressValues.push(p),
-    );
-
-    const matchingResult = results.find(
-      (r) =>
-        r.rotorIds[0] === 3 &&
-        r.rotorIds[1] === 2 &&
-        r.rotorIds[2] === 1 &&
-        r.startingPositions[0] === 0 &&
-        r.startingPositions[1] === 0 &&
-        r.startingPositions[2] === 0,
-    );
-    expect(matchingResult).toBeDefined();
-    expect(matchingResult!.reflectorName).toBe('UKW-B');
-    expect(matchingResult!.decryptedText).toBeTruthy();
-    expect(matchingResult!.nlpScore).toBeGreaterThanOrEqual(0);
-    expect(matchingResult!.nlpScore).toBeLessThanOrEqual(100);
-  });
-
-  it('calls onProgress with increasing values up to 1', async () => {
-    jest.useRealTimers();
-    const progressValues: number[] = [];
-
-    await bruteForceSearchAsync(
-      'ZZ',
-      'ZZ',
-      initialRotorState.available,
-      { 2: initialReflectorState.reflectors[2]! },
-      (p) => progressValues.push(p),
-    );
-
-    expect(progressValues.length).toBeGreaterThan(0);
-    expect(progressValues[progressValues.length - 1]).toBe(1);
-    for (let i = 1; i < progressValues.length; i++) {
-      expect(progressValues[i]).toBeGreaterThanOrEqual(progressValues[i - 1]!);
     }
   });
 });

--- a/src/utils/codebreaking.tsx
+++ b/src/utils/codebreaking.tsx
@@ -4,15 +4,7 @@ import type {
   RotorState,
 } from '../types/interfaces';
 import { encryptLetter, stepRotors } from './enigma';
-import { computeIoC, nlpConfidence } from './nlp';
-
-export interface BruteForceResult {
-  rotorIds: number[];
-  reflectorName: string;
-  startingPositions: number[];
-  decryptedText: string;
-  nlpScore: number;
-}
+import { nlpConfidence } from './nlp';
 
 export interface CribSearchResult {
   rotorIds: number[];
@@ -31,7 +23,6 @@ export interface MenuEdge {
 }
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const EMPTY_PLUGBOARD: PlugboardCable = {};
 
 const createRotorWithPosition = (
   rotor: RotorState,
@@ -72,163 +63,7 @@ const generateRotorPermutations = (rotorIds: number[]): number[][] => {
   return permutations;
 };
 
-const IOC_THRESHOLD = 0.05;
 const MAX_CRIB_RESULTS = 20;
-
-const processPermutation = (
-  perm: number[],
-  ciphertext: string,
-  knownPlaintext: string | undefined,
-  allRotors: { [id: number]: RotorState },
-  allReflectors: { [id: number]: ReflectorState },
-): BruteForceResult[] => {
-  const results: BruteForceResult[] = [];
-
-  for (const reflectorId of Object.keys(allReflectors).map(Number)) {
-    const reflector = allReflectors[reflectorId]!;
-    for (let p0 = 0; p0 < 26; p0++) {
-      for (let p1 = 0; p1 < 26; p1++) {
-        for (let p2 = 0; p2 < 26; p2++) {
-          if (knownPlaintext !== undefined) {
-            const checkRotors = [
-              createRotorWithPosition(allRotors[perm[0]!]!, p0),
-              createRotorWithPosition(allRotors[perm[1]!]!, p1),
-              createRotorWithPosition(allRotors[perm[2]!]!, p2),
-            ];
-            const encrypted = encryptString(
-              knownPlaintext,
-              checkRotors,
-              EMPTY_PLUGBOARD,
-              reflector,
-            );
-            if (encrypted === ciphertext.slice(0, knownPlaintext.length)) {
-              const freshRotors = [
-                createRotorWithPosition(allRotors[perm[0]!]!, p0),
-                createRotorWithPosition(allRotors[perm[1]!]!, p1),
-                createRotorWithPosition(allRotors[perm[2]!]!, p2),
-              ];
-              const decryptedText = encryptString(
-                ciphertext,
-                freshRotors,
-                EMPTY_PLUGBOARD,
-                reflector,
-              );
-              results.push({
-                rotorIds: perm,
-                reflectorName: reflector.name,
-                startingPositions: [p0, p1, p2],
-                decryptedText,
-                nlpScore: nlpConfidence(decryptedText),
-              });
-            }
-          } else {
-            const rotors = [
-              createRotorWithPosition(allRotors[perm[0]!]!, p0),
-              createRotorWithPosition(allRotors[perm[1]!]!, p1),
-              createRotorWithPosition(allRotors[perm[2]!]!, p2),
-            ];
-            const decryptedText = encryptString(
-              ciphertext,
-              rotors,
-              EMPTY_PLUGBOARD,
-              reflector,
-            );
-            if (computeIoC(decryptedText) >= IOC_THRESHOLD) {
-              results.push({
-                rotorIds: perm,
-                reflectorName: reflector.name,
-                startingPositions: [p0, p1, p2],
-                decryptedText,
-                nlpScore: nlpConfidence(decryptedText),
-              });
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return results;
-};
-
-export const bruteForceSearch = (
-  ciphertext: string,
-  knownPlaintext: string | undefined,
-  allRotors: { [id: number]: RotorState },
-  allReflectors: { [id: number]: ReflectorState },
-): BruteForceResult[] => {
-  const results: BruteForceResult[] = [];
-  const rotorIds = Object.keys(allRotors).map(Number);
-  const permutations = generateRotorPermutations(rotorIds);
-
-  for (const perm of permutations) {
-    results.push(
-      ...processPermutation(
-        perm,
-        ciphertext,
-        knownPlaintext,
-        allRotors,
-        allReflectors,
-      ),
-    );
-  }
-
-  results.sort((a, b) => b.nlpScore - a.nlpScore);
-  return results;
-};
-
-export const bruteForceSearchAsync = (
-  ciphertext: string,
-  knownPlaintext: string | undefined,
-  allRotors: { [id: number]: RotorState },
-  allReflectors: { [id: number]: ReflectorState },
-  onProgress: (progress: number) => void,
-  isCancelled?: () => boolean,
-): Promise<BruteForceResult[]> => {
-  const rotorIds = Object.keys(allRotors).map(Number);
-  const permutations = generateRotorPermutations(rotorIds);
-  const totalPerms = permutations.length;
-  const allResults: BruteForceResult[] = [];
-
-  return new Promise((resolve) => {
-    let index = 0;
-
-    const processNext = () => {
-      if (isCancelled?.() === true) {
-        resolve([]);
-        return;
-      }
-
-      if (index >= totalPerms) {
-        onProgress(1);
-        setTimeout(() => {
-          if (isCancelled?.() === true) {
-            resolve([]);
-            return;
-          }
-          allResults.sort((a, b) => b.nlpScore - a.nlpScore);
-          resolve(allResults);
-        }, 0);
-        return;
-      }
-
-      const results = processPermutation(
-        permutations[index]!,
-        ciphertext,
-        knownPlaintext,
-        allRotors,
-        allReflectors,
-      );
-      allResults.push(...results);
-      index++;
-      onProgress(index / totalPerms);
-      setTimeout(processNext, 0);
-    };
-
-    // Defer first tick so React can render the searching state before work begins
-    setTimeout(processNext, 0);
-  });
-};
 
 export const findCribPositions = (
   ciphertext: string,


### PR DESCRIPTION
Closes #64

## Summary

- Removes `bruteForceSearch`, `bruteForceSearchAsync`, and `BruteForceResult` from `codebreaking.tsx`
- Removes the brute force tab, plaintext input, and all related state/callbacks from `BreakCipher.tsx` — the screen is now crib-analysis only with no tab switcher
- Removes brute force-only labels (`BRUTE_FORCE_TAB`, `KNOWN_PLAINTEXT_LABEL`, `KNOWN_PLAINTEXT_OPTIONAL_HINT`, `CIPHERTEXT_TOO_LONG`, `INFO_BRUTE_FORCE_TITLE`, `INFO_BRUTE_FORCE_CONTENT`) from `labels.tsx`
- Removes all brute force tests from `codebreaking.test.tsx` and `BreakCipher.test.tsx`; updates remaining tests to reflect the crib-only interface

## Reasons for removal (from issue)

- Ignores the plugboard entirely — will never find the correct config for any message encrypted with cables
- Prohibitively slow in IoC mode (15–50 minutes without known plaintext)
- Superseded by crib search, which is historically accurate, faster, and finds the plugboard

## Test plan

- [ ] `npm run lint` passes with 0 errors
- [ ] `npm test` passes all 103 tests across 20 suites
- [ ] Break Cipher screen shows only crib analysis inputs (no tab bar, no plaintext field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)