### PR TITLE
fix: prevent e2e smoke job from hanging indefinitely

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -9,6 +9,7 @@ jobs:
   e2e-android:
     name: Android Smoke Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
@@ -52,5 +53,5 @@ jobs:
             adb install android/app/build/outputs/apk/debug/app-debug.apk
             adb reverse tcp:8081 tcp:8081
             npx react-native start --reset-cache &
-            until curl -s http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done
+            timeout 120 bash -c 'until curl -s http://localhost:8081/status | grep -q "packager-status:running"; do sleep 2; done' || { echo "Metro bundler did not start in time"; exit 1; }
             maestro test e2e/smoke/


### PR DESCRIPTION
## Summary
- Adds `timeout-minutes: 45` to the `e2e-android` job so it fails fast instead of running up to GitHub's 6-hour default
- Caps the Metro bundler wait loop at 120 seconds with a clear error message if Metro doesn't start in time

## Test plan
- [ ] Trigger the E2E smoke workflow manually and verify it completes or fails within the timeout window
- [ ] Confirm a Metro startup failure surfaces a readable error (not a silent hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)