### PR TITLE
feat: stack Randomize and Encrypt buttons at bottom of settings screen

### DIFF
--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -46,11 +46,13 @@ const makeStyles = (colors: ColorPalette) =>
       flex: 1,
       backgroundColor: colors.background,
     },
-    bottomRow: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      paddingHorizontal: 8,
+    content: {
+      flex: 1,
+    },
+    bottomSection: {
+      paddingHorizontal: 16,
+      paddingBottom: 16,
+      gap: 8,
     },
     infoButton: {
       position: 'absolute',
@@ -106,9 +108,11 @@ export const Settings: FunctionComponent = () => {
         style={styles.infoButton}
         onPress={() => setInfoVisible(true)}
       />
-      <Rotors />
-      <Plugboard />
-      <View style={styles.bottomRow}>
+      <View style={styles.content}>
+        <Rotors />
+        <Plugboard />
+      </View>
+      <View style={styles.bottomSection}>
         <Button
           testID={RANDOMIZE_BUTTON}
           mode='outlined'


### PR DESCRIPTION
## Summary
- Replaced the horizontal side-by-side button row with a vertical stack pinned to the bottom of the screen
- Randomize sits directly above Encrypt Message
- Rotors + Plugboard content area takes `flex: 1` to push the button section down

## Test plan
- [ ] Open the Enigma Machine settings screen and verify Randomize and Encrypt Message are stacked vertically at the bottom
- [ ] Tap Randomize and confirm it still works
- [ ] Tap Encrypt Message and confirm navigation to the keyboard screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)