### PR TITLE
fix: remove outlines from plugboard and rotor selection buttons

### DIFF
--- a/src/components/pages/machine/settings/plugboard/SelectLetterButton.tsx
+++ b/src/components/pages/machine/settings/plugboard/SelectLetterButton.tsx
@@ -31,9 +31,8 @@ export const SelectLetterButton: FunctionComponent<SelectLetterProps> = ({
           return (
             <Button
               key={letter}
-              mode='outlined'
+              mode='text'
               textColor={colors.textPrimary}
-              style={{ borderColor: colors.border }}
               onPress={() => updateLetter(letter)}
               testID={`${testID ?? 'test'}${index}`}
             >

--- a/src/components/pages/machine/settings/rotors/ChangeIndexModal.tsx
+++ b/src/components/pages/machine/settings/rotors/ChangeIndexModal.tsx
@@ -52,9 +52,8 @@ export const ChangeIndexModal: FunctionComponent<ChangeIndexModalProps> = ({
                 <Button
                   key={`${letter}${currentRotor.id.toString()}`}
                   testID={letterButton(letter, currentRotor.id)}
-                  mode='outlined'
+                  mode='text'
                   textColor={colors.textPrimary}
-                  style={{ borderColor: colors.border }}
                   onPress={() => updateIndex(letter)}
                 >
                   {letter}

--- a/src/components/pages/machine/settings/rotors/RotorSelectModal.tsx
+++ b/src/components/pages/machine/settings/rotors/RotorSelectModal.tsx
@@ -52,9 +52,8 @@ export const RotorSelectModal: FunctionComponent<RotorSelectModalProps> = ({
               <Button
                 key={rotor.id}
                 testID={selectRotorButton(rotor.id)}
-                mode='outlined'
+                mode='text'
                 textColor={colors.textPrimary}
-                style={{ borderColor: colors.border }}
                 onPress={() => chooseRotor(rotor)}
               >
                 {rotor.id}


### PR DESCRIPTION
## Summary
- Switched plugboard letter picker, rotor letter picker, and rotor selector buttons from `mode='outlined'` to `mode='text'`
- Removes the border/outline from each option in those modals

## Test plan
- [ ] Open plugboard and verify letter selection buttons have no outline
- [ ] Open a rotor and verify the letter (ring setting) picker has no outline
- [ ] Open a rotor slot and verify the rotor selection list has no outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)