### PR TITLE
fix: light-mode background on remove-rotor button

### DIFF
--- a/src/components/pages/machine/settings/rotors/Rotor.tsx
+++ b/src/components/pages/machine/settings/rotors/Rotor.tsx
@@ -95,6 +95,7 @@ export const Rotor: FunctionComponent<RotorProps> = ({ slotIndex }) => {
                   testID={REMOVE_ROTOR_BUTTON}
                   icon='close-circle'
                   mode='contained-tonal'
+                  containerColor={colors.surface}
                   iconColor={colors.destructive}
                   onPress={removeRotor}
                 />


### PR DESCRIPTION
## Summary
- The remove-rotor `IconButton` used `mode='contained-tonal'`, which relies on Material Design's `secondaryContainer` theme token
- The app uses a fully custom colour palette that doesn't wire that token, so Paper fell back to a dark colour in light mode
- Fix: add `containerColor={colors.surface}` to the `IconButton` so the background always comes from the app's own palette (light in light mode, dark in dark mode)

## Test plan
- [ ] Switch app to light mode → remove-rotor button background is light (matches card surface)
- [ ] Switch app to dark mode → remove-rotor button background is dark (unchanged)
- [ ] `npm test` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)