### PR TITLE
fix: fix theme segmented buttons colours in light mode

### DIFF
--- a/src/components/pages/settings/Settings.tsx
+++ b/src/components/pages/settings/Settings.tsx
@@ -116,10 +116,30 @@ export const Settings: FunctionComponent = () => {
             value={theme}
             onValueChange={handleThemeChange}
             buttons={[
-              { value: 'dark', label: SETTINGS_THEME_DARK },
-              { value: 'light', label: SETTINGS_THEME_LIGHT },
-              { value: 'system', label: SETTINGS_THEME_SYSTEM },
+              {
+                value: 'dark',
+                label: SETTINGS_THEME_DARK,
+                uncheckedColor: colors.textPrimary,
+              },
+              {
+                value: 'light',
+                label: SETTINGS_THEME_LIGHT,
+                uncheckedColor: colors.textPrimary,
+              },
+              {
+                value: 'system',
+                label: SETTINGS_THEME_SYSTEM,
+                uncheckedColor: colors.textPrimary,
+              },
             ]}
+            theme={{
+              colors: {
+                secondaryContainer: colors.accent,
+                onSecondaryContainer: colors.background,
+                outline: colors.border,
+                onSurface: colors.textPrimary,
+              },
+            }}
           />
         </SettingsSection>
         <SettingsSection heading={SETTINGS_MACHINE_HEADING}>


### PR DESCRIPTION
## Summary
- Unselected segment labels were unreadable in light mode — fixed by setting `uncheckedColor` and `onSurface` to `textPrimary`
- Selected segment had a dark background — replaced with the `accent` colour via `secondaryContainer`
- Selected label now uses `background` as its colour so it contrasts against the accent
- Border uses `colors.border` to stay consistent with the rest of the UI

## Test plan
- [ ] Switch to light mode and verify all three theme options (Dark / Light / System) are readable
- [ ] Verify the selected option shows the accent background with a contrasting label
- [ ] Verify dark mode still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)