### PR TITLE
fix: move settings info button into header row

### DIFF
--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -54,11 +54,9 @@ const makeStyles = (colors: ColorPalette) =>
       paddingBottom: 16,
       gap: 8,
     },
-    infoButton: {
-      position: 'absolute',
-      right: 0,
-      top: 0,
-      zIndex: 1,
+    headerRow: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
     },
   });
 
@@ -100,14 +98,15 @@ export const Settings: FunctionComponent = () => {
 
   return (
     <View style={styles.screen}>
-      <IconButton
-        testID={INFO_BUTTON}
-        icon='information'
-        iconColor={colors.textSecondary}
-        size={22}
-        style={styles.infoButton}
-        onPress={() => setInfoVisible(true)}
-      />
+      <View style={styles.headerRow}>
+        <IconButton
+          testID={INFO_BUTTON}
+          icon='information'
+          iconColor={colors.textSecondary}
+          size={22}
+          onPress={() => setInfoVisible(true)}
+        />
+      </View>
       <View style={styles.content}>
         <Rotors />
         <Plugboard />


### PR DESCRIPTION
## Summary
- The info button on the machine settings page was absolutely positioned, causing it to overlap the rotor settings controls
- Replaced with an in-flow `headerRow` using `justifyContent: 'flex-end'`, matching the existing pattern on the Keyboard screen

## Test plan
- [ ] Open the machine settings page and verify the info button appears in the top-right corner without overlapping any rotor or plugboard controls
- [ ] Tap the info button and confirm the info sidebar opens correctly
- [ ] Verify layout looks correct on both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)