### PR TITLE
fix: apply theme surface colour to plugboard chips in light mode

### DIFF
--- a/src/components/pages/machine/settings/plugboard/Plugboard.tsx
+++ b/src/components/pages/machine/settings/plugboard/Plugboard.tsx
@@ -51,7 +51,11 @@ export const Plugboard: FunctionComponent = () => {
               )
             }
             closeIcon={'close-circle'}
-            style={{ margin: 4, borderColor: colors.border }}
+            style={{
+              margin: 4,
+              borderColor: colors.border,
+              backgroundColor: colors.surface,
+            }}
             textStyle={{ color: colors.textPrimary }}
           >
             {plugboardChipText(cable, plugboard[cable]!)}


### PR DESCRIPTION
## Summary
- Plugboard cable chips were rendering react-native-paper's default MD3 card background (near-white) in light mode instead of the app's custom `colors.surface` (`#E8E0D0`)
- Added `backgroundColor: colors.surface` to the `Chip` style in `Plugboard.tsx`, consistent with how rotor `Card` components already apply the surface colour

## Test plan
- [ ] Run app in light mode and navigate to the Machine settings screen
- [ ] Add one or more plugboard cables and verify the chip background matches the rest of the surface (warm cream, not white/card)
- [ ] Verify dark mode chips are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)