### PR TITLE
fix: make plugboard chip close buttons visible in light mode

### DIFF
--- a/src/components/pages/machine/settings/plugboard/Plugboard.tsx
+++ b/src/components/pages/machine/settings/plugboard/Plugboard.tsx
@@ -57,6 +57,7 @@ export const Plugboard: FunctionComponent = () => {
               backgroundColor: colors.surface,
             }}
             textStyle={{ color: colors.textPrimary }}
+            theme={{ colors: { onSurfaceVariant: colors.textSecondary } }}
           >
             {plugboardChipText(cable, plugboard[cable]!)}
           </Chip>


### PR DESCRIPTION
## Summary
- The close (×) buttons on plugboard cable chips were near-invisible in light mode
- Root cause: the Chip component's close icon colour is driven by `onSurfaceVariant` in the paper theme, which was not being overridden and defaulted to something that blended into the light surface
- Fix: add `theme={{ colors: { onSurfaceVariant: colors.textSecondary } }}` to each Chip so the close icon uses the themed text colour in both light and dark modes

## Test plan
- [ ] Add a plugboard cable and verify the close button is clearly visible in light mode
- [ ] Verify the close button is still visible in dark mode
- [ ] Tap the close button and confirm the cable is removed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)