### PR TITLE
feat: move info buttons into nav bar header

### DIFF
--- a/src/components/pages/breakCipher/BreakCipher.test.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.test.tsx
@@ -23,6 +23,16 @@ import {
 } from '../../../utils/test-utils';
 import { BreakCipher } from './BreakCipher';
 
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual<object>('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      setOptions: jest.fn(),
+    }),
+  };
+});
+
 jest.mock('../../../utils/codebreaking', () => {
   const actual = jest.requireActual<object>('../../../utils/codebreaking');
   return {

--- a/src/components/pages/breakCipher/BreakCipher.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.tsx
@@ -1,5 +1,6 @@
+import { useNavigation } from '@react-navigation/native';
 import type { FunctionComponent } from 'react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Button, IconButton, TextInput } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -179,10 +180,6 @@ const makeStyles = (colors: ColorPalette) =>
       textAlign: 'center',
       marginTop: 16,
       fontSize: 14,
-    },
-    infoRow: {
-      alignItems: 'flex-end',
-      marginBottom: -4,
     },
     nlpBadge: {
       borderRadius: 4,
@@ -374,6 +371,7 @@ export const BreakCipher: FunctionComponent = () => {
     (state: RootState) => state.codeBreaking.lastCribSearch,
   );
 
+  const navigation = useNavigation();
   const [infoVisible, setInfoVisible] = useState(false);
   const [ciphertext, setCiphertext] = useState('');
   const [crib, setCrib] = useState('');
@@ -381,6 +379,20 @@ export const BreakCipher: FunctionComponent = () => {
 
   const colors = useThemeColors();
   const styles = useMemo(() => makeStyles(colors), [colors]);
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <IconButton
+          testID={INFO_BUTTON}
+          icon='information'
+          iconColor={colors.textSecondary}
+          size={22}
+          onPress={() => setInfoVisible(true)}
+        />
+      ),
+    });
+  }, [navigation, colors.textSecondary, setInfoVisible]);
 
   const isSearching = searchStatus === 'searching';
 
@@ -409,16 +421,6 @@ export const BreakCipher: FunctionComponent = () => {
 
   return (
     <ScrollView style={styles.screen}>
-      <View style={styles.infoRow}>
-        <IconButton
-          testID={INFO_BUTTON}
-          icon='information'
-          iconColor={colors.textSecondary}
-          size={20}
-          onPress={() => setInfoVisible(true)}
-        />
-      </View>
-
       <TextInput
         testID={CIPHERTEXT_INPUT}
         label={CIPHERTEXT_LABEL}

--- a/src/components/pages/breakCipher/__integration__/RealBruteForce.test.tsx
+++ b/src/components/pages/breakCipher/__integration__/RealBruteForce.test.tsx
@@ -21,6 +21,16 @@ import {
 } from '../../../../utils/test-utils';
 import { BreakCipher } from '../BreakCipher';
 
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual<object>('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      setOptions: jest.fn(),
+    }),
+  };
+});
+
 // Limit to rotors I–III and one reflector so the real search completes quickly
 // (6 permutations × 17,576 positions vs the full 60 × 3 × 17,576).
 // __esModule must be explicit — jest.requireActual returns it as non-enumerable

--- a/src/components/pages/machine/__integration__/ConfigureAndEncrypt.test.tsx
+++ b/src/components/pages/machine/__integration__/ConfigureAndEncrypt.test.tsx
@@ -27,7 +27,9 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: jest.fn(),
       goBack: jest.fn(),
+      getParent: () => ({ setOptions: jest.fn() }),
     }),
+    useFocusEffect: jest.fn(),
   };
 });
 

--- a/src/components/pages/machine/keyboard/Keyboard.test.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.test.tsx
@@ -18,7 +18,9 @@ jest.mock('@react-navigation/native', () => {
     ...actualNav,
     useNavigation: () => ({
       goBack: mockGoBack,
+      getParent: () => ({ setOptions: jest.fn() }),
     }),
+    useFocusEffect: jest.fn(),
   };
 });
 

--- a/src/components/pages/machine/keyboard/Keyboard.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.tsx
@@ -1,5 +1,6 @@
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { FunctionComponent } from 'react';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Text, View } from 'react-native';
 import {
   Button,
@@ -57,11 +58,31 @@ export const Keyboard: FunctionComponent = () => {
   const colors = useThemeColors();
   const keyboardStyles = useMemo(() => makeKeyboardStyles(colors), [colors]);
 
+  const navigation = useNavigation();
   const [outputLetter, setOutputLetter] = useState<string | null>(null);
   const [message, setMessage] = useState('');
   const [infoVisible, setInfoVisible] = useState(false);
   const [pasteVisible, setPasteVisible] = useState(false);
   const [pasteInput, setPasteInput] = useState('');
+
+  useFocusEffect(
+    useCallback(() => {
+      navigation.getParent()?.setOptions({
+        headerRight: () => (
+          <IconButton
+            testID={INFO_BUTTON}
+            icon='information'
+            iconColor={colors.textSecondary}
+            size={22}
+            onPress={() => setInfoVisible(true)}
+          />
+        ),
+      });
+      return () => {
+        navigation.getParent()?.setOptions({ headerRight: undefined });
+      };
+    }, [navigation, colors.textSecondary, setInfoVisible]),
+  );
 
   const allRotorsSelected = (): boolean =>
     selectedRotorIds.every((id) => id !== null);
@@ -178,13 +199,6 @@ export const Keyboard: FunctionComponent = () => {
             iconColor={colors.textSecondary}
             size={22}
             onPress={() => setPasteVisible(true)}
-          />
-          <IconButton
-            testID={INFO_BUTTON}
-            icon='information'
-            iconColor={colors.textSecondary}
-            size={22}
-            onPress={() => setInfoVisible(true)}
           />
         </View>
       </View>

--- a/src/components/pages/machine/settings/Settings.test.tsx
+++ b/src/components/pages/machine/settings/Settings.test.tsx
@@ -14,7 +14,9 @@ jest.mock('@react-navigation/native', () => {
     ...actualNav,
     useNavigation: () => ({
       navigate: mockNavigate,
+      getParent: () => ({ setOptions: jest.fn() }),
     }),
+    useFocusEffect: jest.fn(),
   };
 });
 

--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -1,6 +1,6 @@
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { FunctionComponent } from 'react';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Button, IconButton } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -55,10 +55,6 @@ const makeStyles = (colors: ColorPalette) =>
       paddingBottom: 16,
       gap: 8,
     },
-    headerRow: {
-      flexDirection: 'row',
-      justifyContent: 'flex-end',
-    },
   });
 
 export const Settings: FunctionComponent = () => {
@@ -71,6 +67,25 @@ export const Settings: FunctionComponent = () => {
     (state: RootState) => state.rotors.selectedSlots,
   );
   const allRotorsSelected = selectedSlots.every((id) => id !== null);
+
+  useFocusEffect(
+    useCallback(() => {
+      navigation.getParent()?.setOptions({
+        headerRight: () => (
+          <IconButton
+            testID={INFO_BUTTON}
+            icon='information'
+            iconColor={colors.textSecondary}
+            size={22}
+            onPress={() => setInfoVisible(true)}
+          />
+        ),
+      });
+      return () => {
+        navigation.getParent()?.setOptions({ headerRight: undefined });
+      };
+    }, [navigation, colors.textSecondary, setInfoVisible]),
+  );
 
   const navigateToNextItem = () => {
     navigation.navigate('Keyboard');
@@ -103,15 +118,6 @@ export const Settings: FunctionComponent = () => {
 
   return (
     <View style={styles.screen}>
-      <View style={styles.headerRow}>
-        <IconButton
-          testID={INFO_BUTTON}
-          icon='information'
-          iconColor={colors.textSecondary}
-          size={22}
-          onPress={() => setInfoVisible(true)}
-        />
-      </View>
       <View style={styles.content}>
         <Rotors />
         <Plugboard />


### PR DESCRIPTION
## Summary

- Removes the inline info `IconButton` from `BreakCipher`, machine `Settings`, and `Keyboard` screen bodies
- Uses `navigation.setOptions({ headerRight })` (BreakCipher) and `useFocusEffect` + `navigation.getParent()?.setOptions` (machine stack screens) to place the info icon in the top-right of the nav bar on each screen
- Updates all affected test mocks to include `getParent` and `useFocusEffect`

## Test plan

- [ ] Info icon appears in the top-right of the nav bar on Break a cipher, Enigma machine settings, and Keyboard screens
- [ ] Tapping the info icon opens the correct `InfoSidebar` for each screen
- [ ] Navigating between Settings and Keyboard correctly swaps the info button content (settings info vs keyboard info)
- [ ] All 119 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)