### PR TITLE
fix: restore info button on Keyboard screen after navigation

### DIFF
--- a/src/components/pages/machine/keyboard/Keyboard.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.tsx
@@ -78,9 +78,6 @@ export const Keyboard: FunctionComponent = () => {
           />
         ),
       });
-      return () => {
-        navigation.getParent()?.setOptions({ headerRight: undefined });
-      };
     }, [navigation, colors.textSecondary, setInfoVisible]),
   );
 

--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -81,9 +81,6 @@ export const Settings: FunctionComponent = () => {
           />
         ),
       });
-      return () => {
-        navigation.getParent()?.setOptions({ headerRight: undefined });
-      };
     }, [navigation, colors.textSecondary, setInfoVisible]),
   );
 


### PR DESCRIPTION
## Summary

Fixes the info button disappearing on the Keyboard (encrypt/decrypt) screen after navigating from Settings.

**Root cause:** React Navigation fires the incoming screen's focus event *before* the outgoing screen's blur event. The cleanup return in Settings' `useFocusEffect` was therefore clearing the `headerRight` that Keyboard had just set, leaving no info button.

**Fix:** Remove the cleanup returns from both `Settings` and `Keyboard`. Since `useFocusEffect` re-runs its callback every time a screen gains focus, each screen simply re-sets the correct info button when it becomes active — no cleanup is needed.

## Test plan

- [ ] Info button is visible on the Settings screen
- [ ] Pressing "Encrypt Message" navigates to Keyboard — info button is still visible
- [ ] Pressing the info button on Keyboard opens the keyboard info sidebar
- [ ] Going back to Settings — info button shows the settings info sidebar
- [ ] All 120 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)