### PR TITLE
fix: make disabled buttons visible in light mode

### DIFF
--- a/src/components/pages/breakCipher/BreakCipher.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.tsx
@@ -268,6 +268,12 @@ const RunButton: FunctionComponent<{
       buttonColor={colors.accent}
       textColor={colors.background}
       disabled={disabled}
+      theme={{
+        colors: {
+          surfaceDisabled: colors.disabledSurface,
+          onSurfaceDisabled: colors.disabledText,
+        },
+      }}
     >
       {RUN_ANALYSIS}
     </Button>

--- a/src/components/pages/machine/keyboard/Keyboard.tsx
+++ b/src/components/pages/machine/keyboard/Keyboard.tsx
@@ -162,6 +162,12 @@ export const Keyboard: FunctionComponent = () => {
               buttonColor={colors.accent}
               textColor={colors.background}
               disabled={pasteInput.length === 0}
+              theme={{
+                colors: {
+                  surfaceDisabled: colors.disabledSurface,
+                  onSurfaceDisabled: colors.disabledText,
+                },
+              }}
               onPress={() => processTextInput(pasteInput)}
             >
               {PASTE_CONFIRM}

--- a/src/theme/colors.tsx
+++ b/src/theme/colors.tsx
@@ -7,6 +7,8 @@ export interface ColorPalette {
   textSecondary: string;
   accent: string;
   destructive: string;
+  disabledSurface: string;
+  disabledText: string;
 }
 
 export const darkColors: ColorPalette = {
@@ -18,6 +20,8 @@ export const darkColors: ColorPalette = {
   textSecondary: '#E0E0E0',
   accent: '#FFD700',
   destructive: '#9c2a2a',
+  disabledSurface: '#3a3a3a',
+  disabledText: '#666666',
 };
 
 export const lightColors: ColorPalette = {
@@ -29,6 +33,8 @@ export const lightColors: ColorPalette = {
   textSecondary: '#5A4A3A',
   accent: '#B8860B',
   destructive: '#9c2a2a',
+  disabledSurface: '#C5BAA8',
+  disabledText: '#7A6A5A',
 };
 
 export const getColors = (theme: 'dark' | 'light'): ColorPalette =>


### PR DESCRIPTION
## Summary
- Adds `disabledSurface` and `disabledText` colour tokens to `ColorPalette` with theme-appropriate values for both light and dark modes
- Overrides React Native Paper's `surfaceDisabled`/`onSurfaceDisabled` theme tokens on the Run Analysis button (Break Cipher) and the Paste confirm button (Keyboard) so disabled state is legible in light mode

## Test plan
- [ ] Switch to light mode and open the Break Cipher screen — verify the Run Analysis button is visible when disabled (before entering ciphertext)
- [ ] Open the paste modal on the Keyboard screen — verify the confirm button is visible when disabled (before entering text)
- [ ] Confirm both buttons still appear correctly in dark mode
- [ ] Confirm both buttons look correct when enabled in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)