### PR TITLE
fix: make disabled Encrypt Message button visible in light mode

### DIFF
--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -136,6 +136,12 @@ export const Settings: FunctionComponent = () => {
           buttonColor={colors.accent}
           textColor={colors.background}
           disabled={!allRotorsSelected}
+          theme={{
+            colors: {
+              surfaceDisabled: colors.disabledSurface,
+              onSurfaceDisabled: colors.disabledText,
+            },
+          }}
         >
           {ENCRYPT_MESSAGE}
         </Button>


### PR DESCRIPTION
## Summary
- Applies the `disabledSurface`/`disabledText` theme token override (introduced in #94) to the **Encrypt Message** button on the Settings screen, which becomes disabled when not all 3 rotors are selected

## Test plan
- [ ] Switch to light mode and open the Settings screen with no rotors selected — verify the Encrypt Message button is visible when disabled
- [ ] Confirm the button looks correct when enabled (all 3 rotors selected) in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)