### PR TITLE
feat: add Clear button to Settings alongside Randomize

### DIFF
--- a/src/components/pages/machine/settings/Settings.test.tsx
+++ b/src/components/pages/machine/settings/Settings.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ENCRYPT_MESSAGE_BUTTON } from '../../../../constants';
+import { CLEAR_BUTTON, ENCRYPT_MESSAGE_BUTTON } from '../../../../constants';
 import { initialReflectorState } from '../../../../features/reflector';
 import { initialRotorState } from '../../../../features/rotors/features';
 import { fireEvent, render, screen } from '../../../../utils/test-utils';
@@ -39,6 +39,12 @@ describe(`Settings`, () => {
 
   it(`disables Encrypt Message button when rotors are not fully selected`, async () => {
     await render(<Settings />);
+    expect(screen.getByTestId(ENCRYPT_MESSAGE_BUTTON)).toBeDisabled();
+  });
+
+  it(`clears rotor and plugboard state when Clear button is pressed`, async () => {
+    await render(<Settings />, { preloadedState: allRotorsSelectedState });
+    await fireEvent.press(screen.getByTestId(CLEAR_BUTTON));
     expect(screen.getByTestId(ENCRYPT_MESSAGE_BUTTON)).toBeDisabled();
   });
 });

--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -6,6 +6,8 @@ import { Button, IconButton } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
+  CLEAR_BUTTON,
+  CLEAR_SETTINGS,
   ENCRYPT_MESSAGE,
   ENCRYPT_MESSAGE_BUTTON,
   INFO_BUTTON,
@@ -55,6 +57,13 @@ const makeStyles = (colors: ColorPalette) =>
       paddingBottom: 16,
       gap: 8,
     },
+    buttonRow: {
+      flexDirection: 'row',
+      gap: 8,
+    },
+    rowButton: {
+      flex: 1,
+    },
   });
 
 export const Settings: FunctionComponent = () => {
@@ -91,6 +100,11 @@ export const Settings: FunctionComponent = () => {
     navigation.navigate('Keyboard');
   };
 
+  const clearSettings = () => {
+    dispatch(resetRotors());
+    dispatch(clearPlugboard());
+  };
+
   const randomizeSettings = () => {
     dispatch(resetRotors());
     dispatch(clearPlugboard());
@@ -123,15 +137,26 @@ export const Settings: FunctionComponent = () => {
         <Plugboard />
       </View>
       <View style={styles.bottomSection}>
-        <Button
-          testID={RANDOMIZE_BUTTON}
-          mode='outlined'
-          textColor={colors.textPrimary}
-          style={{ borderColor: colors.border }}
-          onPress={randomizeSettings}
-        >
-          {RANDOMIZE_SETTINGS}
-        </Button>
+        <View style={styles.buttonRow}>
+          <Button
+            testID={CLEAR_BUTTON}
+            mode='outlined'
+            textColor={colors.textPrimary}
+            style={[{ borderColor: colors.border }, styles.rowButton]}
+            onPress={clearSettings}
+          >
+            {CLEAR_SETTINGS}
+          </Button>
+          <Button
+            testID={RANDOMIZE_BUTTON}
+            mode='outlined'
+            textColor={colors.textPrimary}
+            style={[{ borderColor: colors.border }, styles.rowButton]}
+            onPress={randomizeSettings}
+          >
+            {RANDOMIZE_SETTINGS}
+          </Button>
+        </View>
         <Button
           mode='contained'
           onPress={navigateToNextItem}

--- a/src/constants/labels.tsx
+++ b/src/constants/labels.tsx
@@ -53,6 +53,7 @@ export const SETTINGS_RESET_CONFIRM = 'Reset';
 export const SETTINGS_RESET_CANCEL = 'Cancel';
 
 export const RANDOMIZE_SETTINGS = 'Randomize';
+export const CLEAR_SETTINGS = 'Clear';
 
 export const PASTE_TEXT = 'Feed text';
 export const PASTE_TEXT_PLACEHOLDER = 'Enter text to encrypt / decrypt';

--- a/src/constants/selectors.tsx
+++ b/src/constants/selectors.tsx
@@ -37,6 +37,7 @@ export const INFO_SIDEBAR = 'infoSidebar';
 export const INFO_SIDEBAR_CLOSE = 'infoSidebarClose';
 
 export const RANDOMIZE_BUTTON = 'randomizeButton';
+export const CLEAR_BUTTON = 'clearButton';
 export const PASTE_TEXT_BUTTON = 'pasteTextButton';
 export const PASTE_TEXT_INPUT = 'pasteTextInput';
 export const PASTE_CONFIRM_BUTTON = 'pasteConfirmButton';


### PR DESCRIPTION
## Summary
- Adds a **Clear** button to the Enigma machine Settings screen, placed on the same row as the existing **Randomize** button
- Pressing Clear resets all rotor selections and plugboard cables to defaults
- Both buttons share equal width via `flex: 1` in a `buttonRow` layout
- Adds `CLEAR_SETTINGS` label and `CLEAR_BUTTON` testID constants
- Adds a test verifying the Clear button resets rotor state

## Test plan
- [ ] Press **Clear** — all three rotor slots are deselected and plugboard cables are removed
- [ ] Press **Randomize** — rotors and plugboard are populated with random values (existing behaviour unchanged)
- [ ] **Encrypt a message** button remains disabled after pressing Clear (no rotors selected)
- [ ] Both buttons display side-by-side at equal width on the Settings screen
- [ ] `npm test` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)