### PR TITLE
feat: add vertical spacing between drawer menu items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,7 @@ const App: FunctionComponent = () => {
           drawerStyle: { backgroundColor: colors.background },
           drawerActiveTintColor: colors.accent,
           drawerInactiveTintColor: colors.textPrimary,
+          drawerItemStyle: { marginVertical: 4 },
           headerStyle: { backgroundColor: colors.surface },
           headerTintColor: colors.textPrimary,
         }}


### PR DESCRIPTION
## Summary
- Adds `marginVertical: 4` to `drawerItemStyle` in the drawer `screenOptions`, giving each menu item a small gap so they're no longer flush against each other.

## Test plan
- [ ] Open the drawer and verify all four menu items (Enigma machine, Break a cipher, About Enigma, Settings) have visible spacing between them
- [ ] Confirm active/inactive tint colours and navigation still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)