### PR TITLE
fix: apply safe area bottom inset to all remaining screens

### DIFF
--- a/src/components/pages/about/About.tsx
+++ b/src/components/pages/about/About.tsx
@@ -1,6 +1,7 @@
 import type { FunctionComponent } from 'react';
 import React, { useMemo } from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import {
   ABOUT_CODEBREAKERS_BODY,
@@ -14,7 +15,7 @@ import {
 import type { ColorPalette } from '../../../theme/colors';
 import { useThemeColors } from '../../../theme/useThemeColors';
 
-const makeStyles = (colors: ColorPalette) =>
+const makeStyles = (colors: ColorPalette, bottomInset: number = 0) =>
   StyleSheet.create({
     screen: {
       flex: 1,
@@ -22,7 +23,7 @@ const makeStyles = (colors: ColorPalette) =>
     },
     scrollContent: {
       padding: 20,
-      paddingBottom: 40,
+      paddingBottom: 40 + bottomInset,
     },
     title: {
       color: colors.accent,
@@ -70,7 +71,11 @@ const AboutSection: FunctionComponent<{ heading: string; body: string }> = ({
 
 export const About: FunctionComponent = () => {
   const colors = useThemeColors();
-  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const styles = useMemo(
+    () => makeStyles(colors, bottomInset),
+    [colors, bottomInset],
+  );
   return (
     <View style={styles.screen}>
       <ScrollView contentContainerStyle={styles.scrollContent}>

--- a/src/components/pages/breakCipher/BreakCipher.tsx
+++ b/src/components/pages/breakCipher/BreakCipher.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent } from 'react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Button, IconButton, TextInput } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -85,12 +86,15 @@ const nlpBadgeColor = (score: number): string => {
   return '#F44336';
 };
 
-const makeStyles = (colors: ColorPalette) =>
+const makeStyles = (colors: ColorPalette, bottomInset: number = 0) =>
   StyleSheet.create({
     screen: {
       flex: 1,
       backgroundColor: colors.background,
       padding: 16,
+    },
+    contentContainer: {
+      paddingBottom: 16 + bottomInset,
     },
     tabs: {
       marginBottom: 16,
@@ -384,7 +388,11 @@ export const BreakCipher: FunctionComponent = () => {
   const [expandedPosition, setExpandedPosition] = useState<number | null>(null);
 
   const colors = useThemeColors();
-  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const styles = useMemo(
+    () => makeStyles(colors, bottomInset),
+    [colors, bottomInset],
+  );
 
   useEffect(() => {
     navigation.setOptions({
@@ -426,7 +434,10 @@ export const BreakCipher: FunctionComponent = () => {
   const runAnalysisButtonDisabled = !isCribReady || isSearching;
 
   return (
-    <ScrollView style={styles.screen}>
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.contentContainer}
+    >
       <TextInput
         testID={CIPHERTEXT_INPUT}
         label={CIPHERTEXT_LABEL}

--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Button, IconButton } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -41,7 +42,7 @@ const shuffleArray = <T,>(arr: T[]): T[] => {
   return result;
 };
 
-const makeStyles = (colors: ColorPalette) =>
+const makeStyles = (colors: ColorPalette, bottomInset: number = 0) =>
   StyleSheet.create({
     screen: {
       flex: 1,
@@ -52,7 +53,7 @@ const makeStyles = (colors: ColorPalette) =>
     },
     bottomSection: {
       paddingHorizontal: 16,
-      paddingBottom: 16,
+      paddingBottom: 16 + bottomInset,
       gap: 8,
     },
   });
@@ -60,7 +61,11 @@ const makeStyles = (colors: ColorPalette) =>
 export const Settings: FunctionComponent = () => {
   const navigation = useNavigation<NextScreenNavigationProp>();
   const colors = useThemeColors();
-  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const styles = useMemo(
+    () => makeStyles(colors, bottomInset),
+    [colors, bottomInset],
+  );
   const [infoVisible, setInfoVisible] = useState(false);
   const dispatch = useDispatch();
   const selectedSlots = useSelector(

--- a/src/components/pages/settings/Settings.tsx
+++ b/src/components/pages/settings/Settings.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent } from 'react';
 import React, { useMemo } from 'react';
 import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Button, SegmentedButtons } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -26,7 +27,7 @@ import type { ColorPalette } from '../../../theme/colors';
 import { useThemeColors } from '../../../theme/useThemeColors';
 import type { Theme } from '../../../types';
 
-const makeStyles = (colors: ColorPalette) =>
+const makeStyles = (colors: ColorPalette, bottomInset: number = 0) =>
   StyleSheet.create({
     screen: {
       flex: 1,
@@ -34,7 +35,7 @@ const makeStyles = (colors: ColorPalette) =>
     },
     scrollContent: {
       padding: 20,
-      paddingBottom: 40,
+      paddingBottom: 40 + bottomInset,
     },
     section: {
       marginBottom: 32,
@@ -86,7 +87,11 @@ export const Settings: FunctionComponent = () => {
   const dispatch = useDispatch<AppDispatch>();
   const theme = useSelector((state: RootState) => state.settings.theme);
   const colors = useThemeColors();
-  const styles = useMemo(() => makeStyles(colors), [colors]);
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const styles = useMemo(
+    () => makeStyles(colors, bottomInset),
+    [colors, bottomInset],
+  );
 
   const handleThemeChange = (value: string) => {
     dispatch(setTheme(value as Theme));


### PR DESCRIPTION
Ensures the Android virtual navigation bar does not obscure content on About, app Settings, Machine Settings (action buttons), and Break Cipher.