### PR TITLE
feat: make settings content scrollable

### DIFF
--- a/src/components/pages/machine/settings/Settings.tsx
+++ b/src/components/pages/machine/settings/Settings.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { FunctionComponent } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { Button, IconButton } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -129,10 +129,10 @@ export const Settings: FunctionComponent = () => {
 
   return (
     <View style={styles.screen}>
-      <View style={styles.content}>
+      <ScrollView style={styles.content}>
         <Rotors />
         <Plugboard />
-      </View>
+      </ScrollView>
       <View style={styles.bottomSection}>
         <View style={styles.buttonRow}>
           <Button


### PR DESCRIPTION
## Summary
- Wraps the rotor and plugboard section of the Settings screen in a `ScrollView` so users can scroll through their configuration when many plugboard cables are added
- The bottom action buttons (Clear, Randomize, Encrypt Message) remain fixed and are always accessible

## Test plan
- [ ] Add 5+ plugboard cables and verify the settings area scrolls without covering the buttons
- [ ] Verify the Clear, Randomize, and Encrypt Message buttons remain visible and tappable at all times
- [ ] Verify existing rotor and plugboard functionality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)